### PR TITLE
fix: skip tool format conversion for native ST Claude backend (fixes tool_choice double-wrap)

### DIFF
--- a/index.js
+++ b/index.js
@@ -786,19 +786,34 @@ function onChatCompletionSettingsReady(data) {
     // ({ type: "function", function: { ... } }). When the active backend
     // is Anthropic, convert them to the Messages API format so the request
     // doesn't get rejected with an "invalid input tag" error.
+    //
+    // IMPORTANT: Skip when chat_completion_source === 'claude' (native ST Claude backend).
+    // That backend (sendClaudeRequest) does its own OpenAI→Anthropic conversion for both
+    // tools and tool_choice. Converting here first causes double-wrapping:
+    //   'auto' → { type: 'auto' } [TunnelVision] → { type: { type: 'auto' } } [backend] ← bug
+    // It also causes tools to be filtered out by the backend's .filter(t => t.type === 'function').
+    // Only convert when going through a proxy/custom endpoint that does NOT handle the conversion.
     if (data.tools?.length && isAnthropicApi(data)) {
-        const hasOpenAIWrapped = data.tools.some(t => t?.type === 'function' && t.function);
-        if (hasOpenAIWrapped) {
-            data.tools = data.tools.map(convertToolToAnthropicFormat);
-            if (data.tool_choice !== undefined) {
-                const converted = convertToolChoiceToAnthropicFormat(data.tool_choice);
-                if (converted === undefined) {
-                    delete data.tool_choice;
-                } else {
-                    data.tool_choice = converted;
+        let isNativeClaudeBackend = false;
+        try {
+            const ctx = getContext();
+            isNativeClaudeBackend = ctx?.chatCompletionSettings?.chat_completion_source === 'claude';
+        } catch { /* ignore */ }
+
+        if (!isNativeClaudeBackend) {
+            const hasOpenAIWrapped = data.tools.some(t => t?.type === 'function' && t.function);
+            if (hasOpenAIWrapped) {
+                data.tools = data.tools.map(convertToolToAnthropicFormat);
+                if (data.tool_choice !== undefined) {
+                    const converted = convertToolChoiceToAnthropicFormat(data.tool_choice);
+                    if (converted === undefined) {
+                        delete data.tool_choice;
+                    } else {
+                        data.tool_choice = converted;
+                    }
                 }
+                console.log(`[TunnelVision] Converted ${data.tools.length} tool(s) from OpenAI to Anthropic format`);
             }
-            console.log(`[TunnelVision] Converted ${data.tools.length} tool(s) from OpenAI to Anthropic format`);
         }
     }
 


### PR DESCRIPTION
## Bug report

### Symptoms

When using TunnelVision with the **native SillyTavern Claude API backend** (`Chat Completion Source: Claude`), every generation attempt fails with:

```
Chat Completion API error
tool_choice: Input tag '{'type': 'auto'}' found using 'type' does not match
any of the expected tags: 'auto', 'any', 'tool', 'none'
```

The outgoing request contains `tool_choice: { type: { type: 'auto' } }` instead of the expected `{ type: 'auto' }`.

### Root cause

Two layers of conversion were running on the same request:

**Layer 1 — TunnelVision** (`onChatCompletionSettingsReady`):  
Detects OpenAI-wrapped tools and converts `tool_choice` from string to Anthropic object:  
`'auto'` → `{ type: 'auto' }`

**Layer 2 — SillyTavern backend** (`sendClaudeRequest`, `chat-completions.js:265`):  
Always wraps `tool_choice` as `{ type: request.body.tool_choice }`, expecting a string:  
`{ type: 'auto' }` → `{ type: { type: 'auto' } }` ← **rejected by Anthropic**

There was a second silent bug: the backend filters tools with `.filter(t => t.type === 'function')`. TunnelVision's already-converted Anthropic-format tools (`{ name, description, input_schema }`) have no `type: 'function'` property, so **all tools were silently dropped**, sending an empty `tools` array to the API.

### When did this start?

Commit `50fc820` added the Anthropic tool format conversion layer (cherry-picked from aobmax). That setup likely targets a proxy/custom endpoint that does **not** perform the OpenAI→Anthropic conversion. The native ST Claude backend (`sendClaudeRequest`) was already handling this — making the conversion redundant and harmful for the standard setup.

## Fix

Guard the conversion block in `onChatCompletionSettingsReady` with a `chat_completion_source` check.

- **`chat_completion_source === 'claude'`** (native ST Claude backend): skip TunnelVision's conversion — the backend handles both tools and `tool_choice` correctly.
- **Any other source** (proxy, custom endpoint): keep the existing conversion logic as-is.

```js
// Before
if (data.tools?.length && isAnthropicApi(data)) {
    const hasOpenAIWrapped = ...
    if (hasOpenAIWrapped) { /* convert */ }
}

// After
if (data.tools?.length && isAnthropicApi(data)) {
    const ctx = getContext();
    const isNativeClaudeBackend =
        ctx?.chatCompletionSettings?.chat_completion_source === 'claude';

    if (!isNativeClaudeBackend) {
        const hasOpenAIWrapped = ...
        if (hasOpenAIWrapped) { /* convert */ }
    }
}
```

## Test plan

- [x] Native Claude API (`Chat Completion Source: Claude`): generation works, tools are correctly sent, `tool_choice` arrives as `{ type: 'auto' }` at Anthropic
- [ ] Reverse proxy with Claude model: conversion layer still runs when `chat_completion_source !== 'claude'`