### PR TITLE
Fork enhancements: sidecar API config, per-chat lorebooks, resilient undo/cleanup, activity feed, dedup

### DIFF
--- a/activity-feed.js
+++ b/activity-feed.js
@@ -560,10 +560,15 @@ function renderAllItems() {
         return;
     }
 
-    // Sort: active items first (by recency), constant entries pushed to bottom
+    // Sort: newest first, constant entries pushed to bottom.
+    // Coerce `constant` to a boolean: entry items set `constant: false`, while
+    // tool items leave it `undefined`. Comparing the raw values (false !== undefined)
+    // made the comparator non-antisymmetric, so Array.sort produced arbitrary order
+    // (entries floated above newer tool items regardless of timestamp).
     const sorted = [...filtered].sort((a, b) => {
-        if (a.constant !== b.constant) return a.constant ? 1 : -1;
-        return 0; // preserve insertion order within each group
+        const ac = !!a.constant, bc = !!b.constant;
+        if (ac !== bc) return ac ? 1 : -1;
+        return (b.timestamp || 0) - (a.timestamp || 0);
     });
 
     panelBody.replaceChildren();
@@ -959,7 +964,7 @@ export function logSidecarWrite(opType, { lorebook = '', title = '', uid = null,
  * @param {number} [details.charCount] - Approximate character count injected
  * @param {string} [details.reasoning]
  */
-export function logSidecarRetrieval({ nodeIds = [], nodeLabels = [], charCount = 0, reasoning = '' } = {}) {
+export function logSidecarRetrieval({ nodeIds = [], nodeLabels = [], entries = [], charCount = 0, reasoning = '' } = {}) {
     const labels = nodeLabels.length > 0 ? nodeLabels : nodeIds;
     let summary;
     if (labels.length === 1) {
@@ -971,18 +976,33 @@ export function logSidecarRetrieval({ nodeIds = [], nodeLabels = [], charCount =
     }
 
     const modelLabel = getSidecarModelLabel();
-    const items = [{
+    const timestamp = Date.now();
+    const items = [];
+
+    // One Entry row per injected memory (parity with TunnelVision_Search),
+    // so retrieved nodes are individually browsable in the Entries tab.
+    for (const entry of entries) {
+        items.push(createEntryFeedItem({
+            source: 'tunnelvision',
+            lorebook: entry.lorebook || '',
+            uid: entry.uid ?? null,
+            title: entry.title || `UID ${entry.uid ?? '?'}`,
+            timestamp,
+        }));
+    }
+
+    items.push({
         id: nextId++,
         type: 'tool',
         icon: 'fa-satellite-dish',
         verb: 'Sidecar Retrieved',
         color: '#00b894',
         summary,
-        timestamp: Date.now(),
+        timestamp,
         isSidecar: true,
         sidecarModel: modelLabel,
         reasoning,
-    }];
+    });
 
     addFeedItems(items);
 }
@@ -1024,6 +1044,36 @@ export function logConditionalEvaluations(evaluations, conditionalEntries) {
     }
 
     addFeedItems(items);
+}
+
+/**
+ * Log a snapshot revert (message deletion / swipe) to the activity feed.
+ * One summary item per reverted message.
+ * @param {{ deletedCount?: number, restoredCount?: number, treeCount?: number, books?: string[] }} info
+ */
+export function logSnapshotRevert({ deletedCount = 0, restoredCount = 0, treeCount = 0, books = [] } = {}) {
+    if (deletedCount === 0 && restoredCount === 0 && treeCount === 0) return;
+
+    const parts = [];
+    if (deletedCount > 0) parts.push(`${deletedCount} created entr${deletedCount === 1 ? 'y' : 'ies'} removed`);
+    if (restoredCount > 0) parts.push(`${restoredCount} entr${restoredCount === 1 ? 'y' : 'ies'} restored`);
+    if (treeCount > 0) parts.push(`${treeCount} tree${treeCount === 1 ? '' : 's'} restored`);
+
+    const uniqueBooks = [...new Set((books || []).filter(Boolean))];
+    let suffix = '';
+    if (uniqueBooks.length === 1) suffix = ` in ${uniqueBooks[0]}`;
+    else if (uniqueBooks.length > 1) suffix = ` across ${uniqueBooks.length} books`;
+
+    addFeedItems([{
+        id: nextId++,
+        type: 'tool',
+        icon: 'fa-rotate-left',
+        verb: 'Reverted',
+        color: '#e17055',
+        summary: (parts.join(', ') || 'memory reverted') + suffix,
+        timestamp: Date.now(),
+        isSidecar: true,
+    }]);
 }
 
 // ── Entry / Retrieved Entry Helpers ──

--- a/commands.js
+++ b/commands.js
@@ -22,7 +22,7 @@
 
 import { getContext } from '../../../st-context.js';
 import { loadWorldInfo } from '../../../world-info.js';
-import { canReadBook, canWriteBook, getSettings, getSelectedLorebook, getTree, createTreeNode, saveTree, findNodeById } from './tree-store.js';
+import { canReadBook, canWriteBook, getSettings, getSelectedLorebook, getTree, createTreeNode, saveTree, findNodeById, consolidateSiblingNodes } from './tree-store.js';
 import { getActiveTunnelVisionBooks, resolveTargetBook } from './tool-registry.js';
 import { ingestChatMessages } from './tree-builder.js';
 import { createEntry, mergeEntries, splitEntry, forgetEntry, updateEntry, findEntryByUid } from './entry-manager.js';
@@ -572,7 +572,8 @@ const DEDUPE_SIMILARITY_THRESHOLD = 0.55;
 const DEDUPE_MAX_CLUSTERS_PER_BATCH = 8;
 
 /**
- * Find duplicate clusters using trigram similarity on content+title.
+ * Find duplicate clusters using trigram similarity on content+title,
+ * or title-only similarity (matching diagnostics' detection logic).
  * Returns groups of 2+ entries that are near-duplicates of each other.
  */
 function findDuplicateClusters(entries, threshold) {
@@ -588,12 +589,30 @@ function findDuplicateClusters(entries, threshold) {
         if (ra !== rb) parent.set(ra, rb);
     }
 
-    // Compare all pairs
+    function titlesMatch(a, b) {
+        const na = a.toLowerCase().replace(/[^\w\s]/g, ' ').replace(/\s+/g, ' ').trim();
+        const nb = b.toLowerCase().replace(/[^\w\s]/g, ' ').replace(/\s+/g, ' ').trim();
+        if (na === nb) return true;
+        if (na.length > 3 && nb.length > 3 && (na.includes(nb) || nb.includes(na))) {
+            return Math.min(na.length, nb.length) / Math.max(na.length, nb.length) > 0.5;
+        }
+        const wordsA = na.split(' ').filter(w => w.length > 2);
+        const wordsB = nb.split(' ').filter(w => w.length > 2);
+        const [shorter, longer] = wordsA.length <= wordsB.length
+            ? [wordsA, new Set(wordsB)] : [wordsB, new Set(wordsA)];
+        if (shorter.length >= 2) {
+            const overlap = shorter.filter(w => longer.has(w)).length;
+            return overlap / shorter.length >= 0.8;
+        }
+        return false;
+    }
+
+    // Compare all pairs — cluster if title matches OR full-text trigram similarity meets threshold
     for (let i = 0; i < entries.length; i++) {
         for (let j = i + 1; j < entries.length; j++) {
             const textA = `${entries[i].title} ${entries[i].content}`.toLowerCase();
             const textB = `${entries[j].title} ${entries[j].content}`.toLowerCase();
-            if (trigramSimilarity(textA, textB) >= threshold) {
+            if (titlesMatch(entries[i].title, entries[j].title) || trigramSimilarity(textA, textB) >= threshold) {
                 union(entries[i].uid, entries[j].uid);
             }
         }
@@ -784,13 +803,24 @@ Return JSON — an array with one object per cluster:
         }
     }
 
-    if (mergedCount > 0) {
-        toastr.success(
-            `Deduplication complete: ${mergedCount} entries merged into their clusters. ` +
-            `${errorCount > 0 ? `${errorCount} error(s). ` : ''}` +
-            `Absorbed entries moved to "Deduped" node for review.`,
-            'TunnelVision',
-        );
+    // Consolidate near-duplicate tree category nodes
+    let nodesConsolidated = 0;
+    const tree = getTree(bookName);
+    if (tree?.root) {
+        nodesConsolidated = consolidateSiblingNodes(tree.root);
+        if (nodesConsolidated > 0) saveTree(bookName, tree);
+    }
+
+    if (mergedCount > 0 || nodesConsolidated > 0) {
+        const entryMsg = mergedCount > 0
+            ? `${mergedCount} entr${mergedCount === 1 ? 'y' : 'ies'} merged into their clusters. `
+            : '';
+        const nodeMsg = nodesConsolidated > 0
+            ? `${nodesConsolidated} category node${nodesConsolidated === 1 ? '' : 's'} consolidated. `
+            : '';
+        const errMsg = errorCount > 0 ? `${errorCount} error(s). ` : '';
+        const absorbMsg = mergedCount > 0 ? 'Absorbed entries moved to "Deduped" node for review.' : '';
+        toastr.success(`Deduplication complete: ${entryMsg}${nodeMsg}${errMsg}${absorbMsg}`, 'TunnelVision');
     } else {
         toastr.warning(
             `Deduplication finished but no merges succeeded (${errorCount} error(s)).`,

--- a/constants.js
+++ b/constants.js
@@ -104,7 +104,7 @@ export const AUTO_CLASSIFY_THRESHOLD = 0.35;
  *
  * @see post-turn-processor.js — analyzeExchange dedup logic
  */
-export const DEDUP_SIMILARITY_THRESHOLD = 0.7;
+export const DEDUP_SIMILARITY_THRESHOLD = 0.62;
 
 /**
  * Minimum trigram overlap to even consider two entries as duplicate
@@ -467,7 +467,7 @@ export const LIFECYCLE_SIMILARITY_BUDGET_RATIO = 0.6;
  *
  * @see post-turn-processor.js — analyzeExchange
  */
-export const MAX_EXISTING_FACTS = 50;
+export const MAX_EXISTING_FACTS = 150;
 
 /**
  * Minimum character mention count across extracted facts before

--- a/diagnostics.js
+++ b/diagnostics.js
@@ -85,6 +85,7 @@ export async function runDiagnostics() {
     results.push(checkAutoSummaryConfig());
     results.push(checkMultiBookMode());
     results.push(await checkSidecarConfig());
+    results.push(await checkEmbeddingConfig());
     results.push(...await checkTrackerUids());
     results.push(...checkArcNodes());
     results.push(checkNotebookConfig());
@@ -1153,49 +1154,43 @@ function checkMultiBookMode() {
     return warn(`Invalid multi-book mode "${oldValue}". Auto-reset to "unified".`);
 }
 
-/** Check sidecar LLM configuration: connection profile, API key availability. */
+/** Check sidecar LLM configuration (self-contained profile — no ST secrets). */
 async function checkSidecarConfig() {
     const settings = getSettings();
-    const profileId = settings.connectionProfile;
+    const profile = settings.sidecarProfile;
 
-    if (!profileId) {
-        return pass('Sidecar LLM: not configured (using ST generateRaw fallback)');
+    if (!profile?.enabled) {
+        return pass('Sidecar LLM: disabled (using ST generateRaw fallback)');
     }
 
-    const { findConnectionProfile } = await import('./tree-store.js');
-    const profile = findConnectionProfile(profileId);
-
-    if (!profile) {
-        return warn(`Sidecar: Connection profile "${profileId}" not found. It may have been deleted from Connection Manager.`);
+    const { getSidecarConfig } = await import('./llm-sidecar.js');
+    const config = getSidecarConfig();
+    if (!config) {
+        return warn('Sidecar LLM is enabled but endpoint or API key is missing. Fill in the Sidecar LLM profile in TunnelVision settings.');
     }
 
-    if (!profile.api || !profile.model) {
-        return warn(`Sidecar: Connection profile "${profile.name}" is missing API provider or model. Sidecar calls will fall back to generateRaw.`);
+    return pass(`Sidecar LLM: ${config.format} → ${config.model || '(model unset)'} @ ${config.endpoint}`);
+}
+
+/** Check embedding sidecar configuration. */
+async function checkEmbeddingConfig() {
+    const settings = getSettings();
+    const profile = settings.embeddingProfile;
+
+    if (!profile?.enabled) {
+        return pass('Embedding sidecar: disabled');
     }
 
-    // Verify API key is available via ST's secrets system
-    try {
-        const { fetchSecretKey, isSidecarKeyAvailable } = await import('./llm-sidecar.js');
-        const PROVIDER_SECRET_MAP = {
-            openai: 'api_key_openai', claude: 'api_key_claude', openrouter: 'api_key_openrouter',
-            makersuite: 'api_key_makersuite', deepseek: 'api_key_deepseek', mistralai: 'api_key_mistralai',
-            groq: 'api_key_groq', custom: 'api_key_custom', xai: 'api_key_xai',
-        };
-        const secretKey = PROVIDER_SECRET_MAP[profile.api];
-        if (secretKey) {
-            const key = await fetchSecretKey(secretKey);
-            if (!key) {
-                if (!isSidecarKeyAvailable()) {
-                    return warn(`Sidecar: API key access was denied (HTTP 403). Set "allowKeysExposure: true" in SillyTavern\'s config.yaml so TunnelVision can read keys for direct sidecar calls.`);
-                }
-                return warn(`Sidecar: No API key found for "${profile.api}". Add your key in ST\'s API settings.`);
-            }
-        }
-    } catch (e) {
-        return warn(`Sidecar: Failed to verify API key: ${e.message}`);
+    const { getEmbeddingConfig, isEmbeddingSupported } = await import('./llm-sidecar.js');
+    const config = getEmbeddingConfig();
+    if (!config) {
+        return warn('Embedding sidecar is enabled but the endpoint is missing.');
+    }
+    if (!isEmbeddingSupported()) {
+        return warn(`Embedding sidecar format "${config.format}" is not supported (use openai, google, or gemini).`);
     }
 
-    return pass(`Sidecar LLM: "${profile.name}" (${profile.api} / ${profile.model})`);
+    return pass(`Embedding sidecar: ${config.format} → ${config.model || '(model unset)'} @ ${config.endpoint}`);
 }
 
 /** Check tracker UIDs reference valid entries, auto-remove stale, auto-detect title-based trackers. */
@@ -1544,8 +1539,8 @@ function checkSidecarAutoRetrieval() {
         return pass('Sidecar auto-retrieval: disabled');
     }
 
-    if (!settings.connectionProfile) {
-        return warn('Sidecar auto-retrieval is enabled but no connection profile is selected. Auto-retrieval requires a sidecar connection profile.');
+    if (!settings.sidecarProfile?.enabled) {
+        return warn('Sidecar auto-retrieval is enabled but the Sidecar LLM profile is disabled. Enable and configure it in TunnelVision settings.');
     }
 
     const maxTokens = settings.sidecarMaxInjectionTokens ?? 4000;
@@ -1562,8 +1557,8 @@ function checkSidecarPostGenWriter() {
         return pass('Sidecar post-gen writer: disabled');
     }
 
-    if (!settings.connectionProfile) {
-        return warn('Sidecar post-gen writer is enabled but no connection profile is selected. The writer requires a sidecar connection profile.');
+    if (!settings.sidecarProfile?.enabled) {
+        return warn('Sidecar post-gen writer is enabled but the Sidecar LLM profile is disabled. Enable and configure it in TunnelVision settings.');
     }
 
     const maxOps = settings.sidecarWriterMaxOps ?? 5;
@@ -1585,8 +1580,8 @@ function checkConditionalTriggers() {
         return warn('Narrative conditionals are enabled but sidecar auto-retrieval is OFF. Conditionals require auto-retrieval to evaluate. Enable "Auto-Retrieve Before Generation" in sidecar settings.');
     }
 
-    if (!settings.connectionProfile) {
-        return warn('Narrative conditionals are enabled but no sidecar connection profile is selected. Conditionals require a sidecar LLM to evaluate scene state.');
+    if (!settings.sidecarProfile?.enabled) {
+        return warn('Narrative conditionals are enabled but the Sidecar LLM profile is disabled. Conditionals require a sidecar LLM to evaluate scene state.');
     }
 
     return pass('Narrative conditionals: enabled (conditions on entries will be evaluated by sidecar)');

--- a/entry-manager.js
+++ b/entry-manager.js
@@ -14,6 +14,8 @@ import {
     loadWorldInfo,
     createWorldInfoEntry,
     saveWorldInfo,
+    deleteWorldInfoEntry,
+    deleteWIOriginalDataValue,
 } from '../../../world-info.js';
 import {
     getTree,
@@ -70,9 +72,10 @@ export function invalidateWorldInfoCache(bookName) {
  * @param {string} params.comment - Entry title/comment
  * @param {string[]} [params.keys] - Primary trigger keys
  * @param {string} [params.nodeId] - Tree node to assign to (defaults to root)
+ * @param {string} [params.tv_tracker] - Optional tracking keyword for sidecar auto-cleanup
  * @returns {Promise<{uid: number, comment: string, nodeLabel: string}>}
  */
-export async function createEntry(bookName, { content, comment, keys, nodeId }) {
+export async function createEntry(bookName, { content, comment, keys, nodeId, tv_tracker }) {
     if (!content || !content.trim()) {
         throw new Error('Entry content cannot be empty.');
     }
@@ -94,18 +97,40 @@ export async function createEntry(bookName, { content, comment, keys, nodeId }) 
     // Populate fields
     newEntry.content = content.trim();
     newEntry.comment = comment.trim();
-    if (Array.isArray(keys) && keys.length > 0) {
-        newEntry.key = keys.map(k => String(k).trim()).filter(Boolean);
+    
+    let finalKeys = [];
+    if (Array.isArray(keys)) {
+        finalKeys = keys.map(k => String(k).trim()).filter(Boolean);
     }
+    
+    // Store tracking data as a native keyword so ST doesn't strip it
+    if (tv_tracker) {
+        finalKeys.push(tv_tracker);
+    }
+    
+    if (finalKeys.length > 0) {
+        newEntry.key = finalKeys;
+    }
+    
     // TunnelVision-managed entries: disable keyword triggering since retrieval is tree-based
     newEntry.selective = false;
     newEntry.constant = false;
     newEntry.disable = false;
 
-    // Persist to disk
+    // 1. Persist lorebook to disk FIRST (assigns final server-side UID)
     await saveWorldInfo(bookName, bookData, true);
+    
+    // 2. Refresh the local reference to get the assigned UID
+    const freshBook = await loadWorldInfo(bookName);
+    const finalizedEntry = Object.values(freshBook.entries).find(e => 
+        e.comment === comment.trim() && e.content === content.trim()
+    );
 
-    // Assign to tree node
+    if (!finalizedEntry) {
+        throw new Error('Failed to retrieve finalized entry after save.');
+    }
+
+    // 3. Assign to tree node using the FINAL UID
     let nodeLabel = 'Root';
     const tree = getTree(bookName);
     if (tree && tree.root) {
@@ -117,18 +142,19 @@ export async function createEntry(bookName, { content, comment, keys, nodeId }) 
                 nodeLabel = found.label;
             }
         }
-        addEntryToNode(targetNode, newEntry.uid);
+        addEntryToNode(targetNode, finalizedEntry.uid);
         saveTree(bookName, tree);
-    } else {
-        nodeLabel = '(no tree)';
     }
 
-    if (isTrackerTitle(newEntry.comment)) {
-        setTrackerUid(bookName, newEntry.uid, true);
+    // 4. Force SillyTavern UI to update
+    forceSTLorebookUIUpdate(bookName);
+
+    if (isTrackerTitle(finalizedEntry.comment)) {
+        setTrackerUid(bookName, finalizedEntry.uid, true);
     }
 
-    console.log(`[TunnelVision] Created entry "${comment}" (UID ${newEntry.uid}) in "${bookName}" → ${nodeLabel}`);
-    return { uid: newEntry.uid, comment: newEntry.comment, nodeLabel };
+    console.log(`[TunnelVision] Created entry "${comment}" (UID ${finalizedEntry.uid}) in "${bookName}" → ${nodeLabel}`);
+    return { uid: finalizedEntry.uid, comment: finalizedEntry.comment, nodeLabel };
 }
 
 /**
@@ -204,13 +230,8 @@ export async function forgetEntry(bookName, uid, hardDelete = false) {
     let action;
 
     if (hardDelete) {
-        // Find the correct key for this UID (keys are NOT the same as UIDs in ST)
-        for (const key of Object.keys(bookData.entries)) {
-            if (bookData.entries[key].uid === uid) {
-                delete bookData.entries[key];
-                break;
-            }
-        }
+        await deleteWorldInfoEntry(bookData, uid, { silent: true });
+        deleteWIOriginalDataValue(bookData, uid);
         action = 'deleted';
     } else {
         entry.disable = true;
@@ -389,12 +410,8 @@ export async function mergeEntries(bookName, keepUid, removeUid, opts = {}) {
 
     // Disable or delete the absorbed entry
     if (opts.hardDelete) {
-        for (const key of Object.keys(bookData.entries)) {
-            if (bookData.entries[key].uid === removeUid) {
-                delete bookData.entries[key];
-                break;
-            }
-        }
+        await deleteWorldInfoEntry(bookData, removeUid, { silent: true });
+        deleteWIOriginalDataValue(bookData, removeUid);
     } else {
         removeEntry.disable = true;
     }
@@ -515,6 +532,17 @@ function findNodeContainingUid(node, uid) {
         if (found) return found;
     }
     return null;
+}
+
+/**
+ * Force SillyTavern's native UI to redraw the entries list for a lorebook.
+ * @param {string} bookName
+ */
+export function forceSTLorebookUIUpdate(bookName) {
+    const sel = document.getElementById('world_editor_select');
+    if (sel && sel.options[sel.selectedIndex]?.textContent === bookName) {
+        sel.dispatchEvent(new Event('change'));
+    }
 }
 
 // ─── Utilities required by post-turn-processor & summary-hierarchy ───
@@ -717,16 +745,15 @@ export const FACT_EXTRACTION_PROMPT = `You are a memory curator for an ongoing r
 
 For each fact, provide:
 - title: A short, descriptive label (e.g. "Elena's fear of fire", "Tavern location")
-- content: The factual information, written in third person
-- keys: 3-5 searchable keywords
+- content: The factual information in third person. If the subject already appears in the "Already Known Facts" list below, write ONLY the new specific detail — do NOT restate who they are or repeat their general description.
+- keys: 3-8 searchable keywords — include character names, locations, objects, themes, and temporal markers
 - significance: "low" | "medium" | "high"
 
 Only extract facts that would be useful to recall in future scenes. Skip transient dialogue, greetings, and meta-commentary.
 
-{{KEYWORD_RULES}}
-
-Recent conversation:
-{{CONTEXT}}
+{existingFactsSection}
+{temporalContext}
+{inputSection}
 
 Respond with ONLY a JSON array of fact objects (no markdown, no code fences).`;
 

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ import { eventSource, event_types, extension_prompt_types, extension_prompt_role
 import { getContext } from '../../../st-context.js';
 import { ToolManager } from '../../../tool-calling.js';
 import { renderExtensionTemplateAsync } from '../../../extensions.js';
-import { getSettings, isLorebookEnabled, setLorebookEnabled, isNativeInjectionBook } from './tree-store.js';
-import { preflightToolRuntimeState, registerTools } from './tool-registry.js';
+import { getSettings, isLorebookEnabled, setLorebookEnabled, getTree, removeEntryFromTree, saveTree, isNativeInjectionBook, migrateSelectedLorebook } from './tree-store.js';
+import { preflightToolRuntimeState, registerTools, getActiveTunnelVisionBooks } from './tool-registry.js';
 import { resetSearchLoopTracker, resetSelectiveRetrievalTracker } from './tools/search.js';
 import { buildNotebookPrompt, resetNotebookWriteGuard } from './tools/notebook.js';
 import { flushPendingSummaryHide } from './tools/summarize.js';
@@ -33,9 +33,10 @@ import { initCommands } from './commands.js';
 import { initAutoSummary } from './auto-summary.js';
 import { initPostTurnProcessor } from './post-turn-processor.js';
 import { runSidecarRetrieval } from './sidecar-retrieval.js';
-import { runSidecarWriter } from './sidecar-writer.js';
+import { runSidecarWriter, revertMessageSnapshots, revertInvalidSnapshots, hydrateSnapshots } from './sidecar-writer.js';
 import { separateConditions, isEvaluableCondition, formatCondition, EVALUABLE_TYPES, CONDITION_LABELS, getKeywordProbability, setKeywordProbability } from './conditions.js';
-import { loadWorldInfo, saveWorldInfo, world_names } from '../../../world-info.js';
+import { loadWorldInfo, saveWorldInfo, world_names, deleteWorldInfoEntry, deleteWIOriginalDataValue } from '../../../world-info.js';
+import { findEntryByUid } from './entry-manager.js';
 
 const EXTENSION_NAME = 'tunnelvision';
 const EXTENSION_FOLDER = `third-party/TunnelVision`;
@@ -166,11 +167,35 @@ async function init() {
 
     // Post-generation sidecar writer (remember/update after model responds)
     if (event_types.MESSAGE_RECEIVED) {
-        eventSource.on(event_types.MESSAGE_RECEIVED, onMessageReceived);
+        eventSource.on(event_types.MESSAGE_RECEIVED, async (messageIndexOrId, type) => {
+            const context = getContext();
+            // Robust lookup: could be index or UID
+            const msg = context.chat[messageIndexOrId] || context.chat.find(m => m.mesId === messageIndexOrId);
+            const realMsgId = msg?.mesId;
+
+            // If swiped, cleanup old memories and revert updates from the previous response
+            if (type === 'swipe') {
+                await revertInvalidSnapshots();
+                await cleanInvalidSidecarMemories();
+            }
+            await onMessageReceived(realMsgId, type);
+        });
     }
 
-    // Orphaned tool invocations are cleaned during generation preflight. Doing
-    // it directly from MESSAGE_DELETED mutates chat without updating ST's DOM.
+    // Clean up orphaned tool invocations when messages are deleted
+    if (event_types.MESSAGE_DELETED) {
+        eventSource.on(event_types.MESSAGE_DELETED, async (messageIndexOrId) => {
+            cleanOrphanedToolInvocations();
+
+            // ST passes chat.length (post-deletion) as the argument, not the deleted message's ID.
+            // Use revertInvalidSnapshots() which scans all snapshots against the current chat state.
+            await revertInvalidSnapshots();
+
+            // Fallback: full scan for untracked ghosts (keyword-based cleanup)
+            await new Promise(r => setTimeout(r, 300));
+            await cleanInvalidSidecarMemories();
+        });
+    }
 
     // Refresh connection profile dropdown when profiles change
     if (event_types.CONNECTION_PROFILE_CREATED) {
@@ -187,6 +212,15 @@ async function init() {
 }
 
 async function onChatChanged() {
+    // Rehydrate sidecar snapshots from this chat's metadata so revert-on-deletion
+    // survives a page reload / chat switch.
+    hydrateSnapshots();
+    // One-time migration of the legacy global selection into this chat's metadata.
+    // Active-book guard ensures a stale cross-character book is never copied.
+    migrateSelectedLorebook(getActiveTunnelVisionBooks());
+    // Catch slash command deletions (like /cut) which might not emit MESSAGE_DELETED
+    await cleanInvalidSidecarMemories();
+    // autoDetectLorebooks + refreshUI + registerTools
     await refreshRuntimeState('chat changed');
 }
 
@@ -924,18 +958,24 @@ async function onGenerationStarted(type, opts, dryRun) {
     window.TunnelVision_isRecursiveToolPass = isRecursiveToolPass;
     window.TunnelVision_toolRecursionDepth = _toolRecursionDepth;
 
+    const settings = getSettings();
+
     // On recursive passes, clear the mandatory tool prompt so the model isn't
     // told "you MUST call a tool" when it already has tool results and should
     // be writing the actual response. Then skip all other heavy work.
     if (isRecursiveToolPass) {
-        setExtensionPrompt(TV_PROMPT_KEY, '', extension_prompt_types.IN_CHAT, 0, false, extension_prompt_roles.SYSTEM);
+        const mandatoryPosition = mapPositionSetting(settings.mandatoryPromptPosition);
+        const mandatoryDepth = settings.mandatoryPromptDepth ?? 1;
+        const mandatoryRoleSetting = (settings.mandatoryPromptPosition === 'in_chat' && settings.mandatoryPromptRole === 'user')
+            ? 'system' : settings.mandatoryPromptRole;
+        const mandatoryRole = mapRoleSetting(mandatoryRoleSetting);
+        setExtensionPrompt(TV_PROMPT_KEY, '', mandatoryPosition, mandatoryDepth, false, mandatoryRole);
         return;
     }
 
     // Reset per-generation guards (only on first pass, not recursive)
     resetNotebookWriteGuard();
 
-    const settings = getSettings();
     let runtimeState = null;
 
     // Clean up orphaned tool_invocations at the tail of chat (caused by
@@ -1024,8 +1064,8 @@ async function onGenerationStarted(type, opts, dryRun) {
 // once per group member by waiting for the last MESSAGE_RECEIVED.
 let _sidecarWriterDebounceTimer = null;
 
-async function onMessageReceived(_messageId, type) {
-    console.debug(`[TunnelVision] MESSAGE_RECEIVED: messageId=${_messageId} type="${type}"`);
+async function onMessageReceived(messageId, type) {
+    console.debug(`[TunnelVision] MESSAGE_RECEIVED: messageId=${messageId} type="${type}"`);
     // Clear generation guards BEFORE the sidecar writer runs, so that lorebook
     // writes triggered by the writer do not get blocked by the generation guard.
     _generationInProgress = false;
@@ -1064,7 +1104,7 @@ async function onMessageReceived(_messageId, type) {
     }
 
     try {
-        await runSidecarWriter();
+        await runSidecarWriter(messageId);
     } catch (err) {
         console.error('[TunnelVision] Sidecar post-gen writer error:', err);
     }
@@ -1077,6 +1117,92 @@ async function onMessageReceived(_messageId, type) {
  * @param {Object} settings
  */
 const ST_DEFAULT_RECURSE_LIMIT = 5;
+
+/**
+ * Remove any lorebook entries that were created based on messages
+ * that have since been deleted or swiped.
+ */
+async function cleanInvalidSidecarMemories() {
+    const context = getContext();
+    const chat = context.chat;
+    const activeBooks = getActiveTunnelVisionBooks();
+    if (activeBooks.length === 0) return;
+
+    // Build a set of currently valid message IDs and fingerprints
+    const validMessages = new Set();
+    const validFingerprints = new Set();
+    for (const msg of chat) {
+        if (msg.mesId !== undefined) {
+            validMessages.add(String(msg.mesId));
+            const finger = msg.mes ? `${msg.mes.length}_${msg.mes.substring(0, 100).replace(/[^\w]/g, '')}` : '0';
+            validFingerprints.add(`${msg.mesId}:${finger}`);
+        } else {
+            // Legacy chats: messages may not have mesId — use index + content hash
+            const finger = msg.mes ? `${msg.mes.length}_${msg.mes.substring(0, 100).replace(/[^\w]/g, '')}` : '0';
+            if (finger !== '0') validFingerprints.add(finger);
+        }
+    }
+
+    for (const bookName of activeBooks) {
+        const bookData = await loadWorldInfo(bookName);
+        if (!bookData || !bookData.entries) continue;
+
+        let changed = false;
+        const entryKeys = Object.keys(bookData.entries);
+
+        for (const key of entryKeys) {
+            const entry = bookData.entries[key];
+            const comment = entry.comment || '';
+            const keys = entry.key || [];
+
+            let msgId, finger;
+
+            // 1. Check for new keyword-based tracker (!tv_tracker:msgId:hash)
+            const trackerKey = keys.find(k => String(k).startsWith('!tv_tracker:'));
+            if (trackerKey) {
+                const parts = trackerKey.split(':');
+                if (parts.length >= 3) {
+                    msgId = parts[1];
+                    finger = parts.slice(2).join(':');
+                }
+            } else {
+                // 2. Fallback for legacy tagged entries
+                const match = comment.match(/\[TV_SIDECAR:([^:]+):([^\]]+)\]/);
+                if (match) {
+                    msgId = match[1];
+                    finger = match[2];
+                }
+            }
+
+            if (msgId) {
+                const fullKey = `${msgId}:${finger}`;
+                const isMessageValid = msgId === 'untracked' || validMessages.has(msgId);
+                const isFingerprintValid = validFingerprints.has(fullKey) || validFingerprints.has(finger);
+
+                if (!isMessageValid || !isFingerprintValid) {
+                    console.log(`[TunnelVision] Auto-cleaning invalid memory: "${comment.substring(0, 40)}..." (UID ${entry.uid}) in "${bookName}"`);
+
+                    // Remove from tree
+                    const tree = getTree(bookName);
+                    if (tree) {
+                        removeEntryFromTree(tree.root, entry.uid);
+                        saveTree(bookName, tree);
+                    }
+
+                    // Delete from lorebook using ST's native API
+                    await deleteWorldInfoEntry(bookData, entry.uid, { silent: true });
+                    deleteWIOriginalDataValue(bookData, entry.uid);
+                    changed = true;
+                }
+            }
+        }
+
+        if (changed) {
+            await saveWorldInfo(bookName, bookData, true);
+        }
+    }
+}
+
 function applyRecurseLimit(settings) {
     const limit = Number(settings.recurseLimit);
     if (!isFinite(limit) || limit < 1) {

--- a/index.js
+++ b/index.js
@@ -212,6 +212,9 @@ async function init() {
 }
 
 async function onChatChanged() {
+    // Auto-enable pattern-matched lorebooks FIRST so the migration below sees them
+    // in getActiveTunnelVisionBooks() (autoDetect mutates the active-book set).
+    autoDetectLorebooks();
     // Rehydrate sidecar snapshots from this chat's metadata so revert-on-deletion
     // survives a page reload / chat switch.
     hydrateSnapshots();
@@ -220,7 +223,7 @@ async function onChatChanged() {
     migrateSelectedLorebook(getActiveTunnelVisionBooks());
     // Catch slash command deletions (like /cut) which might not emit MESSAGE_DELETED
     await cleanInvalidSidecarMemories();
-    // autoDetectLorebooks + refreshUI + registerTools
+    // refreshUI + guarded registerTools (autoDetect re-run inside is idempotent)
     await refreshRuntimeState('chat changed');
 }
 

--- a/llm-sidecar.js
+++ b/llm-sidecar.js
@@ -1,411 +1,294 @@
 /**
  * TunnelVision LLM Sidecar
- * Direct API calls to LLM providers for tree building, summarization, and ingest.
- * Bypasses ST's generateRaw to give TV full control over its own samplers.
  *
- * Reads provider, model, and endpoint from a Connection Manager profile, then
- * fetches the API key from ST's secrets store. The user never has to configure
- * anything beyond picking a profile -- same UX as before, but now we make direct
- * fetch() calls instead of switching ST's active connection.
+ * Direct API calls to user-configured LLM + embedding endpoints. Config lives in
+ * extension_settings.TunnelVision.sidecarProfile / .embeddingProfile — each object
+ * carries its OWN apiKey. No SillyTavern secrets are read, so allowKeysExposure is
+ * not required (issue #29). Three call formats: openai-compatible, anthropic, google.
  *
- * Modeled on Lumiverse's summarization.js sidecar pattern:
- *   - fetchSecretKey() via ST's /api/secrets/find endpoint
- *   - PROVIDER_CONFIG with per-provider endpoint, auth, and response parsing
- *   - Three format branches: openai-compat, anthropic, google
- *
- * Falls back to ST's generateRaw when no connection profile is configured.
+ * Falls back to ST's generateRaw (handled by callers) when the sidecar is not enabled.
  */
 
-import { getContext } from '../../../st-context.js';
-import { getSettings, findConnectionProfile } from './tree-store.js';
+import { getSettings } from './tree-store.js';
+import { SIDECAR_DEFAULT_TIMEOUT_MS } from './constants.js';
 
 const MODULE_NAME = 'TunnelVision';
-
-// ─── Provider Mapping ───────────────────────────────────────────────
-// Maps ST's chat_completion_source values (stored in profile.api) to
-// the API format, default endpoint, and secret key needed for direct calls.
-
-// ─── Circuit Breaker ────────────────────────────────────────────────
-// Tripped on the first 403 from /api/secrets/find. Prevents repeated
-// attempts when allowKeysExposure is not enabled in ST's config.yaml.
-let _secretKeyFailed = false;
-let _secretKeyWarningShown = false; // only show the toast once per session
-
-const PROVIDER_MAP = {
-    openai:       { format: 'openai',    endpoint: 'https://api.openai.com/v1/chat/completions',              secretKey: 'api_key_openai' },
-    claude:       { format: 'anthropic', endpoint: 'https://api.anthropic.com/v1/messages',                   secretKey: 'api_key_claude' },
-    openrouter:   { format: 'openai',    endpoint: 'https://openrouter.ai/api/v1/chat/completions',           secretKey: 'api_key_openrouter' },
-    makersuite:   { format: 'google',    endpoint: 'https://generativelanguage.googleapis.com/v1beta/models',  secretKey: 'api_key_makersuite' },
-    google:       { format: 'google',    endpoint: 'https://generativelanguage.googleapis.com/v1beta/models',  secretKey: 'api_key_makersuite' },
-    deepseek:     { format: 'openai',    endpoint: 'https://api.deepseek.com/v1/chat/completions',            secretKey: 'api_key_deepseek' },
-    mistralai:    { format: 'openai',    endpoint: 'https://api.mistral.ai/v1/chat/completions',              secretKey: 'api_key_mistralai' },
-    custom:       { format: 'openai',    endpoint: null,                                                       secretKey: 'api_key_custom' },
-    nanogpt:      { format: 'openai',    endpoint: 'https://nano-gpt.com/api/v1/chat/completions',            secretKey: 'api_key_nanogpt' },
-    groq:         { format: 'openai',    endpoint: 'https://api.groq.com/openai/v1/chat/completions',         secretKey: 'api_key_groq' },
-    chutes:       { format: 'openai',    endpoint: 'https://llm.chutes.ai/v1/chat/completions',               secretKey: 'api_key_chutes' },
-    electronhub:  { format: 'openai',    endpoint: 'https://api.electronhub.ai/v1/chat/completions',          secretKey: 'api_key_electronhub' },
-    xai:          { format: 'openai',    endpoint: 'https://api.x.ai/v1/chat/completions',                    secretKey: 'api_key_xai' },
-};
-
-/**
- * Look up provider info from a profile's `api` field.
- * Falls back to OpenAI-compatible format for unknown providers.
- */
-function getProviderInfo(apiSource) {
-    return PROVIDER_MAP[apiSource] || { format: 'openai', endpoint: null, secretKey: null };
-}
-
-// ─── Secret Key Fetching ────────────────────────────────────────────
-
-/**
- * Fetch an API key from SillyTavern's secrets system.
- * Requires allowKeysExposure: true in ST's config.yaml.
- * @param {string} secretKey - The secret key identifier (e.g. 'api_key_openai')
- * @param {string|null} [secretId] - Optional ST connection-profile secret id
- * @returns {Promise<string|null>} The API key or null if unavailable
- */
-export async function fetchSecretKey(secretKey, secretId = null) {
-    if (!secretKey) {
-        console.warn(`[${MODULE_NAME}] fetchSecretKey called with no key identifier — provider may not be in PROVIDER_MAP`);
-        return null;
-    }
-    if (_secretKeyFailed) {
-        console.debug(`[${MODULE_NAME}] fetchSecretKey("${secretKey}"): skipped (circuit breaker tripped from prior 403)`);
-        return null;
-    }
-
-    console.debug(`[${MODULE_NAME}] Fetching secret key: "${secretKey}" from /api/secrets/find${secretId ? ' with profile secret id' : ''}...`);
-
-    try {
-        const response = await fetch('/api/secrets/find', {
-            method: 'POST',
-            headers: getContext().getRequestHeaders(),
-            body: JSON.stringify({ key: secretKey, ...(secretId ? { id: secretId } : {}) }),
-        });
-
-        if (!response.ok) {
-            if (response.status === 403) {
-                _secretKeyFailed = true;
-                console.warn(`[${MODULE_NAME}] Secret key access DENIED (403). allowKeysExposure is NOT enabled in config.yaml. Sidecar disabled for this session.`);
-                if (!_secretKeyWarningShown) {
-                    _secretKeyWarningShown = true;
-                    try {
-                        toastr.warning(
-                            'TunnelVision sidecar disabled: allowKeysExposure is not enabled in ST\'s config.yaml. ' +
-                            'Set allowKeysExposure: true and restart ST to use a separate LLM for TV operations.',
-                            'TunnelVision Sidecar',
-                            { timeOut: 10000 },
-                        );
-                    } catch { /* toastr may not be loaded yet */ }
-                }
-            } else {
-                console.warn(`[${MODULE_NAME}] Secret key fetch failed: HTTP ${response.status} for "${secretKey}"`);
-            }
-            return null;
-        }
-
-        const data = await response.json();
-        const hasValue = !!(data.value);
-        console.debug(`[${MODULE_NAME}] Secret key "${secretKey}": ${hasValue ? 'FOUND (key retrieved)' : 'EMPTY (key not set in ST)'}`);
-        return data.value || null;
-    } catch (error) {
-        console.error(`[${MODULE_NAME}] Error fetching secret key "${secretKey}":`, error);
-        return null;
-    }
-}
-
-/**
- * Returns false when the circuit breaker has been tripped by a 403 from /api/secrets/find.
- * Callers can use this to skip sidecar entirely without attempting a fetch.
- * @returns {boolean}
- */
-export function isSidecarKeyAvailable() {
-    return !_secretKeyFailed;
-}
-
-// ─── Think Block Stripping ──────────────────────────────────────────
-
 const THINK_BLOCK_RE = /<think[\s\S]*?<\/think>/gi;
 
-// ─── Main Sidecar Generate ──────────────────────────────────────────
+// ─── Circuit Breaker ────────────────────────────────────────────────
+// Opens after BREAKER_THRESHOLD consecutive sidecarGenerate failures; a single
+// success resets it. Prevents hammering a misconfigured endpoint.
+const BREAKER_THRESHOLD = 3;
+let _failureCount = 0;
+let _breakerOpen = false;
 
-/**
- * Check whether the sidecar is configured (a connection profile is selected).
- * @returns {boolean}
- */
-export function isSidecarConfigured() {
-    if (_secretKeyFailed) {
-        console.debug(`[${MODULE_NAME}] Sidecar check: DISABLED (secret key 403 circuit breaker tripped)`);
-        return false;
-    }
-    const settings = getSettings();
-    const profileId = settings.connectionProfile;
-    if (!profileId) {
-        console.debug(`[${MODULE_NAME}] Sidecar check: NO PROFILE selected in settings`);
-        return false;
-    }
-    const profile = findConnectionProfile(profileId);
-    if (!profile) {
-        console.debug(`[${MODULE_NAME}] Sidecar check: profile ID "${profileId}" NOT FOUND in Connection Manager`);
-        return false;
-    }
-    const configured = !!(profile.api && profile.model);
-    console.debug(`[${MODULE_NAME}] Sidecar check: profile="${profile.name || profileId}" api="${profile.api || 'MISSING'}" model="${profile.model || 'MISSING'}" → ${configured ? 'CONFIGURED' : 'INCOMPLETE'}`);
-    return configured;
+export function resetCircuitBreaker() {
+    _failureCount = 0;
+    _breakerOpen = false;
 }
 
-/**
- * Get the resolved sidecar model display string (e.g. "nanogpt/deepseek-chat").
- * Returns null if sidecar is not configured.
- * @returns {string|null}
- */
-export function getSidecarModelLabel() {
-    const config = resolveProfileConfig();
-    if (!config) return null;
-    return `${config.provider}/${config.model}`;
+function _recordFailure() {
+    _failureCount += 1;
+    if (_failureCount >= BREAKER_THRESHOLD) _breakerOpen = true;
 }
 
+function _recordSuccess() {
+    _failureCount = 0;
+    _breakerOpen = false;
+}
+
+// ─── Config Resolution ──────────────────────────────────────────────
+
 /**
- * Resolve the connection profile into everything needed for a direct API call.
- * @returns {{ provider: string, format: string, model: string, endpoint: string, secretKey: string|null, secretId: string|null }|null}
+ * Resolve the sidecar generation config from settings.
+ * @returns {{endpoint:string, apiKey:string, model:string, format:string, maxTokens:number, temperature:number}|null}
  */
-function resolveProfileConfig() {
-    const settings = getSettings();
-    const profileId = settings.connectionProfile;
-    if (!profileId) return null;
-
-    const profile = findConnectionProfile(profileId);
-    if (!profile?.api || !profile?.model) return null;
-
-    const info = getProviderInfo(profile.api);
-    const isKnownProvider = !!PROVIDER_MAP[profile.api];
-
-    // For known providers (those in PROVIDER_MAP with a default endpoint), always use
-    // the PROVIDER_MAP endpoint for direct calls. ST stores session-based proxy URLs
-    // in profile['api-url'] (e.g. NanoGPT's /api/subscription/v1) which don't work
-    // for raw Bearer-token fetch() calls. Only fall back to the profile URL for
-    // 'custom' or unknown providers where we have no built-in endpoint.
-    let endpoint = info.endpoint || profile['api-url'] || null;
-    // ST stores session-based proxy URLs (e.g. /api/subscription/v1) that don't
-    // accept Bearer-token auth. Strip the /subscription segment for direct calls.
-    if (endpoint && endpoint.includes('/subscription/')) {
-        endpoint = endpoint.replace('/subscription/', '/');
-        console.debug(`[${MODULE_NAME}] Stripped /subscription from proxy URL for direct API call`);
-    }
-    if (!info.endpoint && endpoint && info.format === 'openai' && !endpoint.endsWith('/chat/completions')) {
-        endpoint = endpoint.replace(/\/+$/, '') + '/chat/completions';
-    }
-
-    console.debug(`[${MODULE_NAME}] Resolved sidecar config:`, {
-        profileName: profile.name || profileId,
-        provider: profile.api,
-        knownProvider: isKnownProvider,
-        format: info.format,
-        model: profile.model,
-        endpoint: endpoint || 'NONE',
-        secretKeyId: info.secretKey || 'NONE',
-        secretId: profile['secret-id'] ? 'set' : 'not set',
-        profileUrl: profile['api-url'] || 'not set',
-    });
-
+export function getSidecarConfig() {
+    const p = getSettings()?.sidecarProfile;
+    if (!p || typeof p !== 'object') return null;
+    if (!p.enabled) return null;
+    const endpoint = String(p.endpoint || '').trim();
+    const apiKey = String(p.apiKey || '').trim();
+    if (!endpoint || !apiKey) return null;
     return {
-        provider: profile.api,
-        format: info.format,
-        model: profile.model,
         endpoint,
-        secretKey: info.secretKey,
-        secretId: profile['secret-id'] || null,
+        apiKey,
+        model: String(p.model || '').trim(),
+        format: String(p.format || 'openai').trim().toLowerCase(),
+        maxTokens: typeof p.maxTokens === 'number' ? p.maxTokens : 1000,
+        temperature: typeof p.temperature === 'number' ? p.temperature : 0.3,
     };
 }
 
+/** True when sidecar is fully configured and the circuit breaker is closed. */
+export function isSidecarConfigured() {
+    return !_breakerOpen && getSidecarConfig() !== null;
+}
+
+/** Display label for the activity feed. */
+export function getSidecarModelLabel() {
+    const config = getSidecarConfig();
+    if (!config) return null;
+    return config.model || 'sidecar';
+}
+
 /**
- * Generate text via direct API call, bypassing ST's generateRaw.
- * Reads provider/model/endpoint from the selected Connection Manager profile.
- *
- * @param {Object} opts
- * @param {string} opts.prompt - The user/main prompt text
- * @param {string} [opts.systemPrompt] - Optional system prompt
- * @returns {Promise<string>} The generated text (think blocks stripped)
- * @throws {Error} On missing config, missing API key, or API errors
+ * Resolve the embedding config from settings. apiKey may be empty (local endpoints).
+ * @returns {{endpoint:string, apiKey:string, model:string, format:string}|null}
+ */
+export function getEmbeddingConfig() {
+    const p = getSettings()?.embeddingProfile;
+    if (!p || typeof p !== 'object') return null;
+    if (!p.enabled) return null;
+    const endpoint = String(p.endpoint || '').trim();
+    if (!endpoint) return null;
+    return {
+        endpoint,
+        apiKey: String(p.apiKey || '').trim(),
+        model: String(p.model || '').trim(),
+        format: String(p.format || 'openai').trim().toLowerCase(),
+    };
+}
+
+/** True when an embedding endpoint is configured with a supported format. */
+export function isEmbeddingSupported() {
+    const config = getEmbeddingConfig();
+    if (!config) return false;
+    return ['openai', 'google', 'gemini'].includes(config.format);
+}
+
+// ─── HTTP helper ────────────────────────────────────────────────────
+
+async function _fetchJson(url, options, label) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), SIDECAR_DEFAULT_TIMEOUT_MS);
+    let response;
+    try {
+        response = await fetch(url, { ...options, signal: controller.signal });
+    } finally {
+        clearTimeout(timer);
+    }
+    if (!response.ok) {
+        let detail = '';
+        try { detail = await response.text(); } catch { /* body may be absent */ }
+        if (detail && detail.length > 300) detail = detail.slice(0, 300) + '… (truncated)';
+        throw new Error(`${label} HTTP ${response.status}${detail ? ` — ${detail}` : ''}`);
+    }
+    return response.json();
+}
+
+// ─── Endpoint normalization ─────────────────────────────────────────
+
+function _normalizeChatEndpoint(endpoint) {
+    if (/\/chat\/completions$/.test(endpoint)) return endpoint;
+    if (/\/v\d+$/.test(endpoint)) return endpoint.replace(/\/+$/, '') + '/chat/completions';
+    return endpoint; // custom proxy path — use as-is
+}
+
+function _modelsBase(endpoint) {
+    const base = endpoint.replace(/\/+$/, '');
+    return /\/models$/.test(base) ? base : base + '/models';
+}
+
+// ─── Generation ─────────────────────────────────────────────────────
+
+/**
+ * Generate text via a direct API call using the configured sidecar profile.
+ * @param {{prompt:string, systemPrompt?:string}} opts
+ * @returns {Promise<string>}
  */
 export async function sidecarGenerate({ prompt, systemPrompt }) {
-    console.debug(`[${MODULE_NAME}] sidecarGenerate called (prompt length: ${prompt?.length || 0})`);
-
-    const config = resolveProfileConfig();
+    if (_breakerOpen) {
+        throw new Error('Sidecar circuit breaker open — too many consecutive failures. Check the Sidecar LLM configuration.');
+    }
+    const config = getSidecarConfig();
     if (!config) {
-        throw new Error('Sidecar not configured: no valid connection profile selected.');
+        throw new Error('Sidecar not configured: enable and fill in the Sidecar LLM profile in TunnelVision settings.');
     }
-
-    const settings = getSettings();
-    const temperature = settings.sidecarTemperature ?? 0.2;
-    const maxTokens = settings.sidecarMaxTokens || 2048;
-
-    const { provider, format, model, endpoint, secretKey, secretId } = config;
-
-    if (!endpoint) {
-        throw new Error(`No endpoint found for provider "${provider}". Set a Server URL in the connection profile.`);
+    const { endpoint, apiKey, model, format, maxTokens, temperature } = config;
+    try {
+        let result;
+        if (format === 'anthropic') {
+            result = await _callAnthropic({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens });
+        } else if (format === 'google') {
+            result = await _callGoogle({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens });
+        } else {
+            result = await _callOpenAI({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens });
+        }
+        _recordSuccess();
+        return typeof result === 'string' ? result.replace(THINK_BLOCK_RE, '').trim() : result;
+    } catch (error) {
+        _recordFailure();
+        throw error;
     }
-
-    // Fetch API key from ST's secrets store
-    const apiKey = await fetchSecretKey(secretKey, secretId);
-    if (!apiKey) {
-        throw new Error(
-            `No API key found for "${provider}". Add your key in SillyTavern's API settings and ensure allowKeysExposure is enabled in config.yaml.`,
-        );
-    }
-
-    console.debug(`[${MODULE_NAME}] Sidecar calling ${format} API: ${provider}/${model} → ${endpoint} (temp=${temperature}, maxTokens=${maxTokens})`);
-
-    let result;
-
-    if (format === 'anthropic') {
-        result = await _callAnthropic({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens });
-    } else if (format === 'google') {
-        result = await _callGoogle({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens });
-    } else {
-        result = await _callOpenAI({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens, provider });
-    }
-
-    // Strip thinking/reasoning blocks
-    const cleaned = typeof result === 'string' ? result.replace(THINK_BLOCK_RE, '').trim() : result;
-    console.debug(`[${MODULE_NAME}] Sidecar response received: ${typeof cleaned === 'string' ? cleaned.length : 0} chars from ${provider}/${model}`);
-    return cleaned;
 }
 
-// ─── Provider-Specific Callers ──────────────────────────────────────
+async function _callOpenAI({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens }) {
+    const url = _normalizeChatEndpoint(endpoint);
+    const headers = { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` };
+    if (/openrouter\.ai/i.test(url)) {
+        headers['HTTP-Referer'] = (typeof window !== 'undefined' && window.location?.origin) || 'https://sillytavern.app';
+        headers['X-Title'] = 'TunnelVision';
+    }
+    const messages = [];
+    if (systemPrompt) messages.push({ role: 'system', content: systemPrompt });
+    messages.push({ role: 'user', content: prompt });
+    const data = await _fetchJson(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ model, messages, temperature, max_tokens: maxTokens }),
+    }, 'Sidecar');
+    return data.choices?.[0]?.message?.content || '';
+}
 
-/**
- * Anthropic Claude API
- */
 async function _callAnthropic({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens }) {
-    const requestBody = {
-        model,
-        max_tokens: maxTokens,
-        system: systemPrompt || '',
-        messages: [{ role: 'user', content: prompt }],
-        temperature,
-    };
-
-    const response = await fetch(endpoint, {
+    const url = /\/messages$/.test(endpoint) ? endpoint : endpoint.replace(/\/+$/, '') + '/messages';
+    const data = await _fetchJson(url, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
             'x-api-key': apiKey,
             'anthropic-version': '2023-06-01',
         },
-        body: JSON.stringify(requestBody),
-    });
-
-    if (!response.ok) {
-        let errorText = await response.text().catch(() => 'Unable to read error');
-        if (errorText.length > 300) errorText = errorText.substring(0, 300) + '... (truncated)';
-        throw new Error(`Anthropic API error: ${response.status} - ${errorText}`);
-    }
-
-    const data = await response.json();
-
-    if (data.content && Array.isArray(data.content)) {
-        const textBlock = data.content.find(block => block.type === 'text');
-        return textBlock?.text || '';
-    }
-    return '';
-}
-
-/**
- * Google AI Studio (Gemini) API
- */
-async function _callGoogle({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens }) {
-    const googleEndpoint = `${endpoint}/${model}:generateContent`;
-
-    const fullPrompt = systemPrompt
-        ? `${systemPrompt}\n\n---\n\n${prompt}`
-        : prompt;
-
-    const requestBody = {
-        safetySettings: [
-            { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
-            { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
-            { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
-            { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
-            { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' },
-        ],
-        contents: [
-            { role: 'user', parts: [{ text: fullPrompt }] },
-        ],
-        generationConfig: {
+        body: JSON.stringify({
+            model,
+            max_tokens: maxTokens,
             temperature,
-            maxOutputTokens: maxTokens,
-        },
-    };
-
-    const response = await fetch(googleEndpoint, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'x-goog-api-key': apiKey,
-        },
-        body: JSON.stringify(requestBody),
-    });
-
-    if (!response.ok) {
-        let errorText = await response.text().catch(() => 'Unable to read error');
-        if (errorText.length > 300) errorText = errorText.substring(0, 300) + '... (truncated)';
-        throw new Error(`Google AI Studio API error: ${response.status} - ${errorText}`);
-    }
-
-    const data = await response.json();
-
-    if (data.candidates?.[0]?.content?.parts?.[0]?.text) {
-        return data.candidates[0].content.parts[0].text;
-    }
-    return '';
+            system: systemPrompt || '',
+            messages: [{ role: 'user', content: prompt }],
+        }),
+    }, 'Sidecar');
+    const block = Array.isArray(data.content)
+        ? data.content.find(b => b.type === 'text' || typeof b.text === 'string')
+        : null;
+    return block?.text || '';
 }
 
+async function _callGoogle({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens }) {
+    const url = `${_modelsBase(endpoint)}/${model}:generateContent?key=${encodeURIComponent(apiKey)}`;
+    const fullPrompt = systemPrompt ? `${systemPrompt}\n\n---\n\n${prompt}` : prompt;
+    const data = await _fetchJson(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            contents: [{ role: 'user', parts: [{ text: fullPrompt }] }],
+            generationConfig: { temperature, maxOutputTokens: maxTokens },
+        }),
+    }, 'Sidecar');
+    return data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+}
+
+// ─── Embeddings ─────────────────────────────────────────────────────
+
 /**
- * OpenAI-compatible API (OpenAI, OpenRouter, DeepSeek, Groq, custom, etc.)
+ * Compute embeddings for a batch of texts using the configured embedding profile.
+ * @param {string[]} texts
+ * @returns {Promise<number[][]>}
  */
-async function _callOpenAI({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens, provider }) {
-    const headers = {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-    };
-
-    // OpenRouter requires additional headers
-    if (provider === 'openrouter') {
-        headers['HTTP-Referer'] = window.location.origin;
-        headers['X-Title'] = 'TunnelVision';
+export async function computeEmbeddings(texts) {
+    const config = getEmbeddingConfig();
+    if (!config) {
+        throw new Error('Embedding not configured: enable and fill in the Embedding profile in TunnelVision settings.');
     }
-
-    const messages = [];
-    if (systemPrompt) {
-        messages.push({ role: 'system', content: systemPrompt });
+    const { endpoint, apiKey, model, format } = config;
+    if (format === 'google' || format === 'gemini') {
+        return _embedGoogle({ endpoint, apiKey, model, texts });
     }
-    messages.push({ role: 'user', content: prompt });
+    return _embedOpenAI({ endpoint, apiKey, model, texts });
+}
 
-    const requestBody = {
-        model,
-        messages,
-        temperature,
-        max_tokens: maxTokens,
-    };
-
-    const response = await fetch(endpoint, {
+async function _embedOpenAI({ endpoint, apiKey, model, texts }) {
+    const url = /\/embeddings$/.test(endpoint) ? endpoint : endpoint.replace(/\/+$/, '') + '/embeddings';
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+    const data = await _fetchJson(url, {
         method: 'POST',
         headers,
-        body: JSON.stringify(requestBody),
-    });
+        body: JSON.stringify({ model, input: texts }),
+    }, 'Embedding');
+    return (data.data || []).map(d => d.embedding);
+}
 
-    if (!response.ok) {
-        let errorText = await response.text().catch(() => 'Unable to read error');
-        // Truncate HTML error pages (e.g. 404 from wrong endpoint) to avoid flooding console
-        if (errorText.length > 300) errorText = errorText.substring(0, 300) + '... (truncated)';
-        throw new Error(`${provider} API error: ${response.status} - ${errorText}`);
+async function _embedGoogle({ endpoint, apiKey, model, texts }) {
+    const url = `${_modelsBase(endpoint)}/${model}:batchEmbedContents?key=${encodeURIComponent(apiKey)}`;
+    const requests = texts.map(text => ({ model: `models/${model}`, content: { parts: [{ text }] } }));
+    const data = await _fetchJson(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requests }),
+    }, 'Embedding');
+    return (data.embeddings || []).map(e => e.values);
+}
+
+// ─── Connectivity tests ─────────────────────────────────────────────
+
+export async function testSidecarConnectivity() {
+    const config = getSidecarConfig();
+    if (!config) return { ok: false, message: 'No sidecar configuration to test.', latencyMs: 0 };
+    const start = Date.now();
+    try {
+        const text = await sidecarGenerate({ prompt: 'Reply with the single word: OK' });
+        const latencyMs = Date.now() - start;
+        if (!text || !String(text).trim()) {
+            return { ok: false, message: 'Empty response from sidecar endpoint.', latencyMs };
+        }
+        return { ok: true, message: `Connected (${latencyMs} ms).`, latencyMs };
+    } catch (error) {
+        return { ok: false, message: `Connection failed: ${error.message}`, latencyMs: Date.now() - start };
     }
+}
 
-    const data = await response.json();
-
-    if (data.choices?.[0]?.message?.content) {
-        return data.choices[0].message.content;
+export async function testEmbeddingConnectivity() {
+    const config = getEmbeddingConfig();
+    if (!config) return { ok: false, message: 'No embedding configuration to test.', latencyMs: 0 };
+    const start = Date.now();
+    try {
+        const vectors = await computeEmbeddings(['TunnelVision connectivity test']);
+        const latencyMs = Date.now() - start;
+        const dims = Array.isArray(vectors?.[0]) ? vectors[0].length : 0;
+        if (!dims) return { ok: false, message: 'Empty embedding response.', latencyMs };
+        return { ok: true, message: `Connected — ${config.model || 'model'} (dimensions: ${dims}).`, latencyMs };
+    } catch (error) {
+        return { ok: false, message: `Connection failed: ${error.message}`, latencyMs: Date.now() - start };
     }
-    return '';
 }

--- a/post-turn-processor.js
+++ b/post-turn-processor.js
@@ -39,7 +39,6 @@ import {
   buildUidMap,
   parseJsonFromLLM,
   recordEntryTemporal,
-  KEYWORD_RULES,
   FACT_EXTRACTION_PROMPT,
 } from "./entry-manager.js";
 import { markAutoSummaryComplete } from "./auto-summary.js";

--- a/settings.html
+++ b/settings.html
@@ -768,20 +768,33 @@
                         <div class="tv-adv-section">
                             <div class="tv-adv-section-title">Sidecar LLM</div>
                             <div class="tv-help-text" style="margin-bottom: 8px;">
-                                Optional: Select a connection profile for TV's LLM operations (tree building, summaries, chat ingest). TV will make direct API calls using the profile's provider, model, and endpoint with its own controlled samplers instead of your chat preset. Requires <b>allowKeysExposure: true</b> in ST's config.yaml. Leave empty to use ST's generateRaw with your current API settings.
+                                Direct API for TV's own LLM operations (tree building, summaries, ingest, retrieval). TV calls the endpoint you set below using its own key — no <code>allowKeysExposure</code> needed. Leave disabled to use ST's current API via generateRaw.
                             </div>
-                            <select id="tv_connection_profile" class="tv-select" style="margin-bottom: 6px;">
-                                <option value="">(Use current API settings)</option>
-                            </select>
+                            <label class="tv-toggle" style="margin-bottom: 6px;">
+                                <input id="tv_sidecar_enabled" type="checkbox" />
+                                <span class="tv-toggle-slider"></span>
+                                <span class="tv-toggle-label">Enable Sidecar LLM</span>
+                            </label>
+                            <div style="display: flex; gap: 8px; margin-bottom: 6px;">
+                                <input type="text" id="tv_sidecar_endpoint" class="tv-text-input" style="flex: 2;" placeholder="Endpoint (e.g. https://api.openai.com/v1)" />
+                                <select id="tv_sidecar_format" class="tv-select" style="flex: 1;">
+                                    <option value="openai">OpenAI-compatible</option>
+                                    <option value="anthropic">Anthropic</option>
+                                    <option value="google">Google</option>
+                                </select>
+                            </div>
+                            <input type="password" id="tv_sidecar_api_key" class="tv-text-input" style="margin-bottom: 6px;" placeholder="API key" autocomplete="off" />
+                            <input type="text" id="tv_sidecar_model" class="tv-text-input" style="margin-bottom: 6px;" placeholder="Model (e.g. gpt-4o-mini)" />
+                            <button id="tv_sidecar_test" class="menu_button" type="button" style="margin-bottom: 6px;">Test Connection</button>
                             <div id="tv_sidecar_sampler_fields" style="display: none;">
                                 <div style="display: flex; gap: 8px; align-items: center;">
                                     <div style="flex: 1;">
-                                        <label class="tv-label" for="tv_sidecar_temperature">Temperature: <span id="tv_sidecar_temp_val">0.2</span></label>
-                                        <input type="range" id="tv_sidecar_temperature" min="0" max="1" step="0.05" value="0.2" />
+                                        <label class="tv-label" for="tv_sidecar_temperature">Temperature: <span id="tv_sidecar_temp_val">0.3</span></label>
+                                        <input type="range" id="tv_sidecar_temperature" min="0" max="1" step="0.05" value="0.3" />
                                     </div>
                                     <div style="flex: 1;">
                                         <label class="tv-label" for="tv_sidecar_max_tokens">Max Tokens</label>
-                                        <input type="number" id="tv_sidecar_max_tokens" class="tv-number-input" min="256" max="32768" step="256" value="2048" />
+                                        <input type="number" id="tv_sidecar_max_tokens" class="tv-number-input" min="256" max="32768" step="256" value="1000" />
                                     </div>
                                 </div>
                                 <!-- Auto-Retrieval (pre-gen) -->
@@ -840,6 +853,29 @@
                                         </div>
                                     </div>
                                 </div>
+                            </div>
+
+                            <div class="tv-adv-subsection" style="margin-top: 12px; border-top: 1px solid var(--SmartThemeBorderColor); padding-top: 8px;">
+                                <div class="tv-adv-section-title">Embedding Sidecar</div>
+                                <div class="tv-help-text" style="margin-bottom: 6px;">
+                                    Optional separate endpoint for embeddings (vector dedup / similarity). API key may be empty for local servers.
+                                </div>
+                                <label class="tv-toggle" style="margin-bottom: 6px;">
+                                    <input id="tv_embedding_enabled" type="checkbox" />
+                                    <span class="tv-toggle-slider"></span>
+                                    <span class="tv-toggle-label">Enable Embedding Sidecar</span>
+                                </label>
+                                <div style="display: flex; gap: 8px; margin-bottom: 6px;">
+                                    <input type="text" id="tv_embedding_endpoint" class="tv-text-input" style="flex: 2;" placeholder="Endpoint (e.g. https://api.openai.com/v1)" />
+                                    <select id="tv_embedding_format" class="tv-select" style="flex: 1;">
+                                        <option value="openai">OpenAI-compatible</option>
+                                        <option value="google">Google</option>
+                                        <option value="gemini">Gemini</option>
+                                    </select>
+                                </div>
+                                <input type="password" id="tv_embedding_api_key" class="tv-text-input" style="margin-bottom: 6px;" placeholder="API key (optional)" autocomplete="off" />
+                                <input type="text" id="tv_embedding_model" class="tv-text-input" style="margin-bottom: 6px;" placeholder="Model (e.g. text-embedding-3-small)" />
+                                <button id="tv_embedding_test" class="menu_button" type="button">Test Connection</button>
                             </div>
                         </div>
                     </div>

--- a/sidecar-retrieval.js
+++ b/sidecar-retrieval.js
@@ -27,9 +27,20 @@ import { getReadableBooks } from './tool-registry.js';
 import { hasEvaluableConditions, separateConditions, mapSelectiveLogic, describeSelectiveLogic, CONDITION_DESCRIPTIONS, CONDITION_LABELS, rollKeywordProbability, formatCondition } from './conditions.js';
 import { isSidecarConfigured, sidecarGenerate, getSidecarModelLabel } from './llm-sidecar.js';
 import { logSidecarRetrieval, logConditionalEvaluations, setSidecarActive } from './activity-feed.js';
+import { getKeywordTriggeredUids } from './index.js';
 import { applyBackgroundPromptAddendum, buildLanguageDirective } from './agent-utils.js';
 
 const TV_SIDECAR_RETRIEVAL_KEY = 'tunnelvision_sidecar_retrieval';
+
+let lastInjectedNodeIds = [];
+
+/**
+ * Get the list of node IDs currently injected into the context by the sidecar.
+ * @returns {string[]}
+ */
+export function getInjectedNodeIds() {
+    return lastInjectedNodeIds;
+}
 
 // ─── Tree Overview (reuses collapsed-tree format from search.js) ─────
 
@@ -233,10 +244,11 @@ function buildConditionalSection(conditionalEntries) {
 /**
  * Resolve node IDs to entry content across all active lorebooks.
  * @param {string[]} nodeIds
- * @returns {Promise<string>}
+ * @returns {Promise<{ text: string, entries: Array<{ lorebook: string, uid: number, title: string }> }>}
  */
 async function resolveNodeContent(nodeIds) {
     const results = [];
+    const entries = [];
     const seenEntries = new Set();
 
     for (const nodeId of nodeIds) {
@@ -256,16 +268,20 @@ async function resolveNodeContent(nodeIds) {
                 if (seenEntries.has(entryKey)) continue;
                 seenEntries.add(entryKey);
 
+                // Skip if already in context via keyword trigger
+                if (getKeywordTriggeredUids().has(Number(uid))) continue;
+
                 const entry = findEntryByUid(bookData.entries, uid);
                 if (!entry?.content || entry.disable) continue;
 
                 const title = entry.comment || entry.key?.[0] || `Entry #${uid}`;
                 results.push(`[${bookName} | ${title}]\n${entry.content}`);
+                entries.push({ lorebook: bookName, uid: Number(uid), title });
             }
         }
     }
 
-    return results.join('\n\n');
+    return { text: results.join('\n\n'), entries };
 }
 
 /**
@@ -401,6 +417,9 @@ async function resolveConditionalContent(evaluations, conditionalEntries) {
     for (const ce of conditionalEntries) {
         if (!acceptedUids.has(ce.uid)) continue;
 
+        // Skip if already in context via keyword trigger
+        if (getKeywordTriggeredUids().has(Number(ce.uid))) continue;
+
         const bookData = await loadWorldInfo(ce.bookName);
         if (!bookData?.entries) continue;
 
@@ -474,6 +493,8 @@ export async function runSidecarRetrieval() {
             return;
         }
 
+        lastInjectedNodeIds = [...nodeIds];
+
         // Injection settings
         const position = mapPosition(settings.mandatoryPromptPosition);
         const depth = settings.mandatoryPromptDepth ?? 1;
@@ -482,9 +503,11 @@ export async function runSidecarRetrieval() {
 
         // Resolve node content (tree-based retrieval)
         let injectionParts = [];
+        let retrievedEntries = [];
 
         if (nodeIds.length > 0) {
-            const nodeContent = await resolveNodeContent(nodeIds);
+            const { text: nodeContent, entries: nodeEntries } = await resolveNodeContent(nodeIds);
+            retrievedEntries = nodeEntries;
             if (nodeContent.trim()) {
                 injectionParts.push(nodeContent);
             }
@@ -531,7 +554,7 @@ export async function runSidecarRetrieval() {
 
         const _modelLabel = getSidecarModelLabel() || 'unknown';
         console.log(`[TunnelVision] Sidecar auto-retrieval [${_modelLabel}]: injected ${nodeIds.length} node(s) + ${conditionalEvaluations.filter(e => e.accepted).length} conditional(s) (~${capped.length} chars)`);
-        logSidecarRetrieval({ nodeIds, nodeLabels, charCount: capped.length, reasoning });
+        logSidecarRetrieval({ nodeIds, nodeLabels, entries: retrievedEntries, charCount: capped.length, reasoning });
 
         // Detailed console output for sidecar transparency
         console.groupCollapsed(`[TunnelVision] Sidecar retrieval details (${_modelLabel})`);
@@ -561,6 +584,7 @@ export async function runSidecarRetrieval() {
  * @param {Object} settings
  */
 function clearRetrievalPrompt(settings) {
+    lastInjectedNodeIds = [];
     const position = mapPosition(settings.mandatoryPromptPosition);
     const depth = settings.mandatoryPromptDepth ?? 1;
     const role = mapRole(settings.mandatoryPromptRole);

--- a/sidecar-writer.js
+++ b/sidecar-writer.js
@@ -16,9 +16,10 @@
  */
 
 import { getContext } from '../../../st-context.js';
-import { loadWorldInfo } from '../../../world-info.js';
+import { loadWorldInfo, saveWorldInfo, deleteWorldInfoEntry, deleteWIOriginalDataValue } from '../../../world-info.js';
 import {
     getTree,
+    saveTree,
     findNodeById,
     getAllEntryUids,
     getSettings,
@@ -31,8 +32,346 @@ import { getDefinition as getSummarizeDef } from './tools/summarize.js';
 import { getDefinition as getForgetDef } from './tools/forget.js';
 import { getDefinition as getReorganizeDef } from './tools/reorganize.js';
 import { getDefinition as getMergeSplitDef } from './tools/merge-split.js';
-import { logSidecarWrite } from './activity-feed.js';
-import { applyBackgroundPromptAddendum, buildLanguageDirective } from './agent-utils.js';
+import { logSidecarWrite, logSnapshotRevert } from './activity-feed.js';
+import { saveSettingsDebounced } from '../../../../script.js';
+import { applyBackgroundPromptAddendum, buildLanguageDirective, trigramSimilarity } from './agent-utils.js';
+
+const SUMMARY_DEDUP_THRESHOLD = 0.50;
+
+// ─── Turn Snapshots (for undos) ──────────────────────────────────
+
+/**
+ * Stores lorebook entry snapshots before they are modified by the sidecar.
+ * Allows reverting updates if a message is deleted or swiped.
+ * Keyed by "msgId:hash".
+ * @type {Map<string, Object>}
+ */
+const turnSnapshots = new Map();
+
+/** chat_metadata key under which snapshots persist across reloads. */
+const SNAPSHOTS_METADATA_KEY = 'tunnelvision_snapshots';
+/** Max snapshots retained (20; bounds chat-file bloat, constant regardless of chat length). */
+const MAX_SNAPSHOTS = 20;
+
+/**
+ * Persist the in-memory snapshot map into chat_metadata so revert-on-deletion
+ * survives a page reload. Stored as a plain object keyed by "msgId:hash".
+ */
+function persistSnapshots() {
+    try {
+        const context = getContext();
+        if (!context.chatMetadata) return;
+        context.chatMetadata[SNAPSHOTS_METADATA_KEY] = Object.fromEntries(turnSnapshots);
+        context.saveMetadataDebounced?.();
+    } catch { /* no active chat */ }
+}
+
+/**
+ * Rehydrate the snapshot map from chat_metadata. Call on init and on
+ * CHAT_CHANGED so reverts work after a reload or chat switch.
+ */
+export function hydrateSnapshots() {
+    try {
+        turnSnapshots.clear();
+        const data = getContext().chatMetadata?.[SNAPSHOTS_METADATA_KEY];
+        if (data && typeof data === 'object') {
+            for (const [key, snap] of Object.entries(data)) {
+                turnSnapshots.set(key, snap);
+            }
+        }
+    } catch { /* no active chat */ }
+}
+
+/**
+ * Take a snapshot of the state of entries about to be modified.
+ * @param {string} snapshotKey
+ * @param {WriteOp[]} ops
+ */
+async function takeSnapshots(snapshotKey, ops) {
+    const snapshots = {
+        createdUids: [], // UIDs of new entries created this turn (to be deleted)
+        modifiedEntries: {}, // Original state of entries updated/merged (to be restored)
+        treeState: {}, // Copy of tree root for each book (to be restored)
+    };
+
+    for (const op of ops) {
+        if (!op.lorebook) continue;
+        const bookData = await loadWorldInfo(op.lorebook);
+        if (!bookData?.entries) continue;
+
+        if (op.type === 'update' || op.type === 'merge' || op.type === 'forget' || op.type === 'split') {
+            const uids = op.type === 'merge' ? [op.keep_uid, op.remove_uid] : [op.uid];
+            for (const uid of uids) {
+                if (uid === undefined) continue;
+                const entry = findEntryByUid(bookData.entries, uid);
+                if (entry) {
+                    const key = `${op.lorebook}:${uid}`;
+                    if (!snapshots.modifiedEntries[key]) {
+                        snapshots.modifiedEntries[key] = JSON.parse(JSON.stringify(entry));
+                    }
+                }
+            }
+        }
+        
+        // Always snapshot the tree state if we might change it
+        if (!snapshots.treeState[op.lorebook]) {
+            const tree = getTree(op.lorebook);
+            if (tree?.root) {
+                snapshots.treeState[op.lorebook] = JSON.parse(JSON.stringify(tree.root));
+            }
+        }
+    }
+
+    turnSnapshots.set(snapshotKey, snapshots);
+
+    // Prune old snapshots (keep last MAX_SNAPSHOTS)
+    while (turnSnapshots.size > MAX_SNAPSHOTS) {
+        const firstKey = turnSnapshots.keys().next().value;
+        turnSnapshots.delete(firstKey);
+    }
+
+    persistSnapshots();
+}
+
+/**
+ * Exported for index.js to use during cleanup.
+ * Reverts any modifications made by the sidecar for a specific message.
+ */
+export async function revertMessageSnapshots(msgId, msgHash) {
+    const key = `${msgId}:${msgHash}`;
+    const snapshots = turnSnapshots.get(key);
+    if (!snapshots) return false;
+
+    console.log(`[TunnelVision] Reverting sidecar modifications for message ${msgId}...`);
+
+    let deletedCount = 0;
+    let restoredCount = 0;
+    const touchedBooks = new Set();
+
+    // 1. Delete created entries
+    for (const item of snapshots.createdUids) {
+        const { bookName, uid } = item;
+        const bookData = await loadWorldInfo(bookName);
+        if (bookData?.entries) {
+            const entry = bookData.entries[uid];
+            if (entry) {
+                console.debug(`   - Deleting created entry: "${entry.comment}" (UID ${uid})`);
+                await deleteWorldInfoEntry(bookData, uid, { silent: true });
+                deleteWIOriginalDataValue(bookData, uid);
+
+                await saveWorldInfo(bookName, bookData, true);
+
+                // Force UI update so it vanishes from the native Lorebook instantly
+                if (typeof window.renderWorldInfoList === 'function') window.renderWorldInfoList();
+                if (typeof window.renderWorldInfo === 'function') window.renderWorldInfo();
+
+                deletedCount++;
+                touchedBooks.add(bookName);
+            }
+        }
+    }
+
+    // 2. Restore modified entries
+    const booksToSave = new Set();
+    for (const [idKey, originalEntry] of Object.entries(snapshots.modifiedEntries)) {
+        const [bookName, uid] = idKey.split(':');
+        const bookData = await loadWorldInfo(bookName);
+        if (bookData?.entries) {
+            const entryKey = Object.keys(bookData.entries).find(k => bookData.entries[k].uid === Number(uid));
+            if (entryKey) {
+                console.debug(`   - Restoring entry: UID ${uid} in "${bookName}"`);
+                bookData.entries[entryKey] = originalEntry;
+                
+                // Deep restore to SillyTavern's underlying array
+                if (bookData.originalData && Array.isArray(bookData.originalData.entries)) {
+                    const origIdx = bookData.originalData.entries.findIndex(x => x.uid === Number(uid));
+                    if (origIdx >= 0) {
+                        bookData.originalData.entries[origIdx] = originalEntry;
+                    }
+                }
+                
+                booksToSave.add(bookName);
+                restoredCount++;
+                touchedBooks.add(bookName);
+            }
+        }
+    }
+    for (const bookName of booksToSave) {
+        const bookData = await loadWorldInfo(bookName);
+        await saveWorldInfo(bookName, bookData, true);
+        if (typeof window.renderWorldInfoList === 'function') window.renderWorldInfoList();
+    }
+
+    // 3. Restore tree states
+    let treeCount = 0;
+    for (const [bookName, originalRoot] of Object.entries(snapshots.treeState)) {
+        const tree = getTree(bookName);
+        if (tree) {
+            console.debug(`   - Restoring tree structure for "${bookName}"`);
+            tree.root = originalRoot;
+            saveTree(bookName, tree);
+            treeCount++;
+            touchedBooks.add(bookName);
+        }
+    }
+
+    turnSnapshots.delete(key);
+    persistSnapshots();
+
+    // Surface the revert in the activity feed — one summary item per message
+    logSnapshotRevert({ deletedCount, restoredCount, treeCount, books: [...touchedBooks] });
+
+    return true;
+}
+
+/**
+ * Scan all stored snapshots and revert any that belong to messages that are
+ * no longer in the chat (or have been modified via swiping).
+ * This completely decouples the undo logic from ST event arguments.
+ */
+export async function revertInvalidSnapshots() {
+    const context = getContext();
+    const chat = context.chat;
+    if (!chat || !turnSnapshots.size) return;
+
+    // Build set of currently valid msgId:msgHash combinations
+    const validHashes = new Set();
+    for (const msg of chat) {
+        const hash = msg.mes ? `${msg.mes.length}_${msg.mes.substring(0, 100).replace(/[^\w]/g, '')}` : '0';
+        if (msg.mesId !== undefined) {
+            validHashes.add(`${msg.mesId}:${hash}`);
+        } else if (hash !== '0') {
+            // Legacy chats: use content-hash-only key for fingerprint matching
+            validHashes.add(hash);
+        }
+    }
+
+    // Revert any snapshot whose key is no longer valid
+    for (const key of turnSnapshots.keys()) {
+        const parts = key.split(':');
+        const msgId = parts[0];
+        const valid = validHashes.has(key);
+        if (!valid) {
+            const msgHash = parts.slice(1).join(':');
+            // Also check: the snapshot's content hash might match a current message's hash
+            // (e.g., when msgId is 'untracked', compare by hash alone)
+            const hashOnly = msgHash;
+            const hashMatches = msgId === 'untracked' && validHashes.has(hashOnly);
+            if (!hashMatches) {
+                console.log(`[TunnelVision] Reverting sidecar snapshot for message ${msgId}`);
+                await revertMessageSnapshots(msgId, msgHash);
+            }
+        }
+    }
+}
+
+// ─── Recent Operations Buffer ────────────────────────────────────
+
+/**
+ * Tracks recent sidecar operations to avoid redundant writes across turns.
+ * Keyed by chatId.
+ * @type {Map<string, Array<{type: string, summary: string, turn: number}>>}
+ */
+const recentOpsBuffer = new Map();
+const MAX_BUFFERED_OPS = 10;
+
+/**
+ * Add an operation to the recent buffer.
+ * @param {string} chatId
+ * @param {string} type
+ * @param {string} summary
+ */
+function bufferOperation(chatId, type, summary) {
+    if (!chatId) return;
+    if (!recentOpsBuffer.has(chatId)) {
+        recentOpsBuffer.set(chatId, []);
+    }
+    const buffer = recentOpsBuffer.get(chatId);
+    buffer.unshift({ type, summary, turn: getContext().chat.length });
+    if (buffer.length > MAX_BUFFERED_OPS) {
+        buffer.pop();
+    }
+}
+
+/**
+ * Format recent operations for the sidecar prompt.
+ * @param {string} chatId
+ * @returns {string}
+ */
+function formatRecentOperations(chatId) {
+    if (!chatId || !recentOpsBuffer.has(chatId)) return '';
+    const buffer = recentOpsBuffer.get(chatId);
+    if (buffer.length === 0) return '';
+
+    let text = '\nRECENT SIDECAR OPERATIONS (already performed):\n';
+    for (const op of buffer) {
+        text += `- Turn ${op.turn} [${op.type}]: ${op.summary}\n`;
+    }
+    return text;
+}
+
+// ─── Summary Dedup ───────────────────────────────────────────────
+
+/**
+ * Load title+body text from all existing [Summary] entries across the given books.
+ * Returns objects so the dedup loop can convert near-duplicates to updates.
+ * @param {string[]} bookNames
+ * @returns {Promise<Array<{text: string, uid: number, lorebook: string}>>}
+ */
+async function loadSummaryTexts(bookNames) {
+    const entries = [];
+    for (const bookName of bookNames) {
+        const bookData = await loadWorldInfo(bookName);
+        if (!bookData?.entries) continue;
+        for (const e of Object.values(bookData.entries)) {
+            if (e.disable) continue;
+            if (!(e.comment || '').startsWith('[Summary]')) continue;
+            const title = (e.comment || '').replace(/^\[Summary\]\s*/, '').trim();
+            const rawContent = e.content || '';
+            const bodyStart = rawContent.indexOf('\n\n');
+            const body = bodyStart >= 0 ? rawContent.slice(bodyStart + 2) : rawContent;
+            entries.push({ text: `${title} ${body}`.toLowerCase(), uid: e.uid, lorebook: bookName });
+        }
+    }
+    return entries;
+}
+
+/**
+ * Format a summarize op's content in the same structure used by tools/summarize.js.
+ * Used when converting a duplicate summarize op into an update op.
+ * @param {Object} op
+ * @returns {string}
+ */
+function formatSummaryContent(op) {
+    const significance = op.significance || 'moderate';
+    const participants = Array.isArray(op.participants) && op.participants.length > 0
+        ? op.participants.join(', ')
+        : '(unspecified)';
+    return `[Scene Summary — ${significance}]\nParticipants: ${participants}\n\n${(op.summary || '').trim()}`;
+}
+
+/**
+ * Load stripped titles of all existing [Summary] entries, most recent first (by UID).
+ * Used to populate the EXISTING SUMMARIES section in the writer prompt so the LLM
+ * sees the full list even when the tree overview truncates the Summaries node.
+ * @param {string[]} bookNames
+ * @returns {Promise<string[]>}
+ */
+async function loadSummaryTitles(bookNames) {
+    const items = [];
+    for (const bookName of bookNames) {
+        const bookData = await loadWorldInfo(bookName);
+        if (!bookData?.entries) continue;
+        for (const e of Object.values(bookData.entries)) {
+            if (e.disable) continue;
+            if (!(e.comment || '').startsWith('[Summary]')) continue;
+            const title = (e.comment || '').replace(/^\[Summary\]\s*/, '').trim();
+            if (title) items.push({ uid: e.uid ?? 0, title });
+        }
+    }
+    items.sort((a, b) => b.uid - a.uid);
+    return items.slice(0, 50).map(i => i.title);
+}
 
 // ─── Tree Overview (shared format with sidecar-retrieval.js) ─────
 
@@ -182,7 +521,7 @@ Rules:
 - "remember" entries are NEW facts/events not already in the lorebook
 - "update" entries modify EXISTING entries (you must reference the UID)
 - "merge" consolidates two EXISTING entries that overlap — specify keep_uid (entry to keep) and remove_uid (entry to absorb)
-- "summarize" creates a scene/event summary for significant narrative beats (filed under a Summaries category)
+- "summarize" creates a permanent narrative record — use ONLY for: first meetings of important characters, arc-ending events, major revelations, character deaths or departures, turning points that definitively change the story direction. Do NOT use for routine dialogue, incremental roleplay, or content already covered by a recent Summaries entry.
 - "forget" disables entries that are no longer relevant (character died, fact proven false, info outdated)
 - "reorganize" moves entries between tree nodes or creates new categories for better organization
 - "split" divides one entry that covers multiple topics into two focused entries
@@ -216,7 +555,8 @@ CRITICAL — Updates must be surgical:
 CRITICAL — Housekeeping:
 - Use "forget" sparingly — only when information is definitively wrong or permanently irrelevant
 - Use "reorganize" when entries are clearly in the wrong category
-- Use "summarize" for significant scenes or narrative beats that should be preserved as events
+- Use "summarize" sparingly — 0 per turn is the norm. Never create a summary when an existing Summaries entry (listed above under EXISTING SUMMARY ENTRIES) already covers the same scene or session. When in doubt, skip it.
+- You can only see recent messages. NEVER use language like "first meeting", "first encounter", "for the first time", or "initial" — you cannot know if this is genuinely a first occurrence. Use neutral, factual language (e.g. "A meeting between X and Y" not "First meeting between X and Y").
 - Do NOT over-organize — only reorganize when there's a clear structural problem
 
 Response format:
@@ -251,12 +591,16 @@ Return ONLY the JSON object, no explanation.`;
  * Build the sidecar writer prompt.
  * @param {string} treeOverview
  * @param {string} recentChat
+ * @param {string} [recentOps]
  * @returns {string}
  */
-function buildWriterPrompt(treeOverview, recentChat) {
+function buildWriterPrompt(treeOverview, recentChat, recentOps = '', summaryTitles = []) {
     const writableBooks = getBookListWithDescriptions({ writableOnly: true });
+    const summarySection = summaryTitles.length > 0
+        ? `\nEXISTING SUMMARY ENTRIES (already recorded — do NOT create duplicates):\n${summaryTitles.map(t => `- ${t}`).join('\n')}\n`
+        : '';
     return `CURRENT LOREBOOK STATE:
-${treeOverview}
+${treeOverview}${summarySection}${recentOps}
 
 WRITABLE LOREBOOKS:
 ${writableBooks}
@@ -423,12 +767,22 @@ function parseWriteOps(response) {
  * Execute parsed write operations via tool action functions.
  * @param {WriteOp[]} ops
  * @param {string} [reasoning]
+ * @param {string|number} [messageId]
  * @returns {Promise<{succeeded: number, failed: number, results: string[]}>}
  */
-async function executeWriteOps(ops, reasoning = '') {
+async function executeWriteOps(ops, reasoning = '', messageId = null) {
     const results = [];
     let succeeded = 0;
     let failed = 0;
+
+    // Generate snapshot key for this turn
+    const lastMsg = getContext().chat[getContext().chat.length - 1];
+    const msgId = messageId ?? lastMsg?.mesId ?? 'untracked';
+    const msgHash = lastMsg?.mes ? `${lastMsg.mes.length}_${lastMsg.mes.substring(0, 100).replace(/[^\w]/g, '')}` : '0';
+    const snapshotKey = `${msgId}:${msgHash}`;
+
+    // Take snapshots before modifying anything
+    await takeSnapshots(snapshotKey, ops);
 
     // Lazily get tool definitions (they rebuild each call to pick up current book list)
     const rememberAction = getRememberDef().action;
@@ -464,6 +818,21 @@ async function executeWriteOps(ops, reasoning = '') {
             }
 
             let result;
+            const context = getContext();
+            const lastMsg = context.chat[context.chat.length - 1];
+            
+            // Resolve message ID reliably
+            let msgId = messageId;
+            if (msgId === null || msgId === undefined) {
+                msgId = lastMsg?.mesId;
+            }
+            if (msgId === null || msgId === undefined) {
+                msgId = 'untracked';
+            }
+
+            const msgHash = lastMsg?.mes ? `${lastMsg.mes.length}_${lastMsg.mes.substring(0, 100).replace(/[^\w]/g, '')}` : '0';
+            const tv_tracker = `!tv_tracker:${msgId}:${msgHash}`;
+
             if (op.type === 'remember') {
                 result = await rememberAction({
                     lorebook: op.lorebook,
@@ -471,6 +840,7 @@ async function executeWriteOps(ops, reasoning = '') {
                     content: op.content,
                     keys: op.keys,
                     node_id: op.node_id,
+                    tv_tracker,
                 });
             } else if (op.type === 'update') {
                 result = await updateAction({
@@ -495,6 +865,7 @@ async function executeWriteOps(ops, reasoning = '') {
                     summary: op.summary,
                     participants: op.participants,
                     significance: op.significance,
+                    tv_tracker,
                 });
             } else if (op.type === 'forget') {
                 result = await forgetAction({
@@ -536,25 +907,42 @@ async function executeWriteOps(ops, reasoning = '') {
             } else {
                 succeeded++;
                 results.push(`OK [${op.type}]: ${result}`);
+
+                // If this was a creation, record the UID for cleanup/undo
+                if (op.type === 'remember' || op.type === 'summarize') {
+                    const uidMatch = String(result).match(/\(UID (\d+)\)/);
+                    if (uidMatch) {
+                        const uid = Number(uidMatch[1]);
+                        const snapshots = turnSnapshots.get(snapshotKey);
+                        if (snapshots) {
+                            snapshots.createdUids.push({ bookName: op.lorebook, uid });
+                        }
+                    }
+                }
+
+                const opSummary = op.type === 'remember'
+                    ? `"${(op.title || '').substring(0, 50)}"`
+                    : op.type === 'merge'
+                    ? `UID ${op.keep_uid ?? '?'} ← UID ${op.remove_uid ?? '?'}${op.title ? ` "${op.title.substring(0, 40)}"` : ''}`
+                    : op.type === 'summarize'
+                    ? `"${(op.title || '').substring(0, 50)}"`
+                    : op.type === 'forget'
+                    ? `UID ${op.uid ?? '?'}: ${(op.reason || '').substring(0, 40)}`
+                    : op.type === 'reorganize'
+                    ? `${op.action || '?'}${op.uid ? ` UID ${op.uid}` : ''}${op.title ? ` "${op.title.substring(0, 30)}"` : ''}`
+                    : op.type === 'split'
+                    ? `UID ${op.uid ?? '?'} → "${(op.new_title || '').substring(0, 40)}"`
+                    : `UID ${op.uid ?? '?'}${op.title ? ` "${op.title.substring(0, 40)}"` : ''}`;
+
+                bufferOperation(getContext().chatId, op.type, opSummary);
+
                 logSidecarWrite(op.type, {
                     lorebook: op.lorebook,
                     title: op.title,
                     uid: op.uid,
                     keep_uid: op.keep_uid,
                     remove_uid: op.remove_uid,
-                    summary: op.type === 'remember'
-                        ? `"${(op.title || '').substring(0, 50)}"`
-                        : op.type === 'merge'
-                        ? `UID ${op.keep_uid ?? '?'} ← UID ${op.remove_uid ?? '?'}${op.title ? ` "${op.title.substring(0, 40)}"` : ''}`
-                        : op.type === 'summarize'
-                        ? `"${(op.title || '').substring(0, 50)}"`
-                        : op.type === 'forget'
-                        ? `UID ${op.uid ?? '?'}: ${(op.reason || '').substring(0, 40)}`
-                        : op.type === 'reorganize'
-                        ? `${op.action || '?'}${op.uid ? ` UID ${op.uid}` : ''}${op.title ? ` "${op.title.substring(0, 30)}"` : ''}`
-                        : op.type === 'split'
-                        ? `UID ${op.uid ?? '?'} → "${(op.new_title || '').substring(0, 40)}"`
-                        : `UID ${op.uid ?? '?'}${op.title ? ` "${op.title.substring(0, 40)}"` : ''}`,
+                    summary: opSummary,
                     reasoning,
                 });
             }
@@ -563,6 +951,11 @@ async function executeWriteOps(ops, reasoning = '') {
             results.push(`ERROR [${op.type}]: ${err.message}`);
         }
     }
+
+    // Re-persist: createdUids were appended to the snapshot during this loop,
+    // after takeSnapshots' initial persist. Without this, created entries
+    // wouldn't be deleted on a revert after a reload.
+    persistSnapshots();
 
     return { succeeded, failed, results };
 }
@@ -573,9 +966,10 @@ async function executeWriteOps(ops, reasoning = '') {
  * Run sidecar post-generation writer.
  * Called after MESSAGE_RECEIVED in index.js.
  *
+ * @param {string|number} [messageId]
  * @returns {Promise<void>}
  */
-export async function runSidecarWriter() {
+export async function runSidecarWriter(messageId = null) {
     const settings = getSettings();
 
     // Guard: must be enabled and sidecar must be configured
@@ -607,9 +1001,12 @@ export async function runSidecarWriter() {
         return;
     }
 
+    const recentOps = formatRecentOperations(getContext().chatId);
+    const summaryTitles = await loadSummaryTitles(activeBooks);
+
     try {
         // Ask sidecar what to write
-        const prompt = buildWriterPrompt(treeOverview, recentChat);
+        const prompt = buildWriterPrompt(treeOverview, recentChat, recentOps, summaryTitles);
         const langDirective = buildLanguageDirective();
         const response = await sidecarGenerate({
             prompt,
@@ -631,12 +1028,59 @@ export async function runSidecarWriter() {
         const maxOps = settings.sidecarWriterMaxOps ?? 5;
         const capped = ops.slice(0, maxOps);
 
+        // Dedup summarize ops — skip if near-identical to an existing summary entry
+        let summaryTexts = null;
+        const dedupedOps = [];
+        for (const op of capped) {
+            if (op.type === 'summarize') {
+                if (!summaryTexts) {
+                    summaryTexts = await loadSummaryTexts(activeBooks);
+                }
+                const newText = `${op.title || ''} ${op.summary || ''}`.toLowerCase();
+                const isDupe = summaryTexts.some(e => trigramSimilarity(newText, e.text) >= SUMMARY_DEDUP_THRESHOLD);
+                if (isDupe) {
+                    // Find the best-matching existing summary and update it instead of creating a new one
+                    const bestMatch = summaryTexts.reduce(
+                        (best, e) => {
+                            const score = trigramSimilarity(newText, e.text);
+                            return score > best.score ? { score, entry: e } : best;
+                        },
+                        { score: 0, entry: null },
+                    ).entry;
+
+                    if (bestMatch?.uid != null) {
+                        console.log(`[TunnelVision] Sidecar writer: updating existing summary UID ${bestMatch.uid} instead of creating duplicate "${op.title}"`);
+                        dedupedOps.push({
+                            type: 'update',
+                            lorebook: bestMatch.lorebook,
+                            uid: bestMatch.uid,
+                            content: formatSummaryContent(op),
+                            title: op.title ? `[Summary] ${op.title}` : undefined,
+                        });
+                    } else {
+                        console.log(`[TunnelVision] Sidecar writer: skipping duplicate summary "${op.title}" (no UID to update)`);
+                    }
+                    continue;
+                }
+                summaryTexts.push({ text: newText, uid: null, lorebook: op.lorebook });
+            }
+            dedupedOps.push(op);
+        }
+        if (dedupedOps.length === 0) {
+            console.log('[TunnelVision] Sidecar post-gen writer: all ops filtered by dedup');
+            return;
+        }
+
         // Execute writes
-        const { succeeded, failed, results } = await executeWriteOps(capped, reasoning);
+        const { succeeded, failed, results } = await executeWriteOps(dedupedOps, reasoning, messageId);
+
+        // Explicitly refresh UI after all modifications are complete
+        const { refreshUI } = await import('./ui-controller.js');
+        refreshUI();
 
         const _writerModel = getSidecarModelLabel() || 'unknown';
         console.log(
-            `[TunnelVision] Sidecar post-gen writer [${_writerModel}]: ${succeeded} succeeded, ${failed} failed out of ${capped.length} operations`,
+            `[TunnelVision] Sidecar post-gen writer [${_writerModel}]: ${succeeded} succeeded, ${failed} failed out of ${dedupedOps.length} operations`,
         );
         for (const r of results) {
             console.debug(`  ${r}`);
@@ -644,7 +1088,7 @@ export async function runSidecarWriter() {
 
         console.groupCollapsed(`[TunnelVision] Sidecar writer details (${_writerModel})`);
         if (reasoning) console.log('Reasoning:', reasoning);
-        for (const op of capped) {
+        for (const op of dedupedOps) {
             if (op.type === 'remember') {
                 console.log(`📝 Remember: "${op.title}" → ${op.lorebook || '(auto)'}`);
                 console.log(`   Content: ${(op.content || '').substring(0, 200)}${(op.content || '').length > 200 ? '...' : ''}`);

--- a/tests/__mocks__/st-world-info.js
+++ b/tests/__mocks__/st-world-info.js
@@ -1,6 +1,8 @@
 export const loadWorldInfo = async () => ({ entries: {} });
 export const createWorldInfoEntry = async () => ({});
 export const saveWorldInfo = async () => {};
+export const deleteWorldInfoEntry = async () => {};
+export const deleteWIOriginalDataValue = () => {};
 export const selected_world_info = [];
 export const world_info = {};
 export const world_names = [];

--- a/tests/diagnostics.test.js
+++ b/tests/diagnostics.test.js
@@ -26,8 +26,6 @@ vi.mock('../tree-store.js', () => ({
     }),
     getBookDescription: vi.fn(() => ''),
     isTrackerTitle: vi.fn(title => /^\[tracker[^\]]*\]/i.test(String(title || '').trim())),
-    getConnectionProfileId: vi.fn(() => null),
-    findConnectionProfile: vi.fn(() => null),
 }));
 
 vi.mock('../tool-registry.js', () => ({

--- a/tests/sidecar-snapshots.test.js
+++ b/tests/sidecar-snapshots.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Host context + heavy local deps mocked so we can exercise snapshot
+// persistence/hydration in isolation.
+vi.mock('../../../st-context.js', () => ({ getContext: vi.fn() }));
+vi.mock('../tree-store.js', () => ({
+    getTree: vi.fn(() => null),
+    saveTree: vi.fn(),
+    findNodeById: vi.fn(),
+    getAllEntryUids: vi.fn(() => []),
+    getSettings: vi.fn(() => ({})),
+}));
+vi.mock('../activity-feed.js', () => ({
+    logSidecarWrite: vi.fn(),
+    logSnapshotRevert: vi.fn(),
+}));
+// Cut transitive import chains to ST-host modules not present in tests.
+vi.mock('../tool-registry.js', () => ({
+    getReadableBooks: vi.fn(() => []),
+    getWritableBooks: vi.fn(() => []),
+    getBookListWithDescriptions: vi.fn(() => ''),
+    checkToolConfirmation: vi.fn(),
+    REMEMBER_NAME: 'remember',
+    UPDATE_NAME: 'update',
+    FORGET_NAME: 'forget',
+    SUMMARIZE_NAME: 'summarize',
+    REORGANIZE_NAME: 'reorganize',
+    MERGESPLIT_NAME: 'mergesplit',
+}));
+vi.mock('../llm-sidecar.js', () => ({
+    isSidecarConfigured: vi.fn(() => false),
+    sidecarGenerate: vi.fn(),
+    getSidecarModelLabel: vi.fn(() => ''),
+}));
+vi.mock('../tools/remember.js', () => ({ getDefinition: vi.fn() }));
+vi.mock('../tools/update.js', () => ({ getDefinition: vi.fn() }));
+vi.mock('../tools/summarize.js', () => ({ getDefinition: vi.fn() }));
+vi.mock('../tools/forget.js', () => ({ getDefinition: vi.fn() }));
+vi.mock('../tools/reorganize.js', () => ({ getDefinition: vi.fn() }));
+vi.mock('../tools/merge-split.js', () => ({ getDefinition: vi.fn() }));
+vi.mock('../agent-utils.js', () => ({
+    applyBackgroundPromptAddendum: vi.fn(),
+    buildLanguageDirective: vi.fn(() => ''),
+    trigramSimilarity: vi.fn(() => 0),
+}));
+
+import { getContext } from '../../../st-context.js';
+import { logSnapshotRevert } from '../activity-feed.js';
+import { hydrateSnapshots, revertMessageSnapshots } from '../sidecar-writer.js';
+
+const SNAP_KEY = 'tunnelvision_snapshots';
+
+function makeContext(metadata) {
+    return {
+        chatId: 'chat-1',
+        chat: [],
+        chatMetadata: metadata,
+        saveMetadataDebounced: vi.fn(),
+    };
+}
+
+describe('sidecar snapshot persistence', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('reverts a snapshot rehydrated from chat metadata (simulates reload)', async () => {
+        const key = '5:42_Hello';
+        const ctx = makeContext({
+            [SNAP_KEY]: {
+                [key]: { createdUids: [], modifiedEntries: {}, treeState: {} },
+            },
+        });
+        getContext.mockReturnValue(ctx);
+
+        // Reload: in-memory map is empty until hydrate pulls it from metadata.
+        hydrateSnapshots();
+
+        const result = await revertMessageSnapshots('5', '42_Hello');
+
+        expect(result).toBe(true);
+        expect(logSnapshotRevert).toHaveBeenCalledTimes(1);
+        // Snapshot consumed and persisted back out of metadata.
+        expect(ctx.chatMetadata[SNAP_KEY][key]).toBeUndefined();
+        expect(ctx.saveMetadataDebounced).toHaveBeenCalled();
+    });
+
+    it('returns false when no snapshot exists for the message', async () => {
+        getContext.mockReturnValue(makeContext({}));
+
+        hydrateSnapshots(); // clears the in-memory map from empty metadata
+
+        const result = await revertMessageSnapshots('99', 'missing');
+
+        expect(result).toBe(false);
+        expect(logSnapshotRevert).not.toHaveBeenCalled();
+    });
+});

--- a/tests/tree-store-selection.test.js
+++ b/tests/tree-store-selection.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { extension_settings } from '../../../extensions.js';
+
+// Local st-context mock exposing chatMetadata + saveMetadataDebounced.
+// Overrides the shared tests/__mocks__/st-context.js, which omits both.
+// `mockChatMetadata` is a `let` so a test can swap it to null ("no active chat").
+let mockChatMetadata = {};
+const mockSaveMetadataDebounced = vi.fn();
+vi.mock('../../../st-context.js', () => ({
+    getContext: () => ({
+        chatMetadata: mockChatMetadata,
+        saveMetadataDebounced: mockSaveMetadataDebounced,
+    }),
+}));
+
+import {
+    getSelectedLorebook,
+    setSelectedLorebook,
+    migrateSelectedLorebook,
+} from '../tree-store.js';
+
+const SELECTED_BOOK_KEY = 'tunnelvision_selected_book';
+
+beforeEach(() => {
+    mockChatMetadata = {};
+    mockSaveMetadataDebounced.mockClear();
+    extension_settings.tunnelvision = {};
+});
+
+describe('getSelectedLorebook / setSelectedLorebook (chat-scoped)', () => {
+    it('writes selection into chat metadata and saves', () => {
+        setSelectedLorebook('Book A');
+        expect(mockChatMetadata[SELECTED_BOOK_KEY]).toBe('Book A');
+        expect(mockSaveMetadataDebounced).toHaveBeenCalledTimes(1);
+    });
+
+    it('reads selection back from chat metadata', () => {
+        mockChatMetadata[SELECTED_BOOK_KEY] = 'Book B';
+        expect(getSelectedLorebook()).toBe('Book B');
+    });
+
+    it('returns null when nothing is selected', () => {
+        expect(getSelectedLorebook()).toBeNull();
+    });
+
+    it('clears the key when selection is falsy', () => {
+        mockChatMetadata[SELECTED_BOOK_KEY] = 'Book A';
+        setSelectedLorebook(null);
+        expect(SELECTED_BOOK_KEY in mockChatMetadata).toBe(false);
+        expect(mockSaveMetadataDebounced).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when there is no active chat', () => {
+        mockChatMetadata = null;
+        expect(getSelectedLorebook()).toBeNull();
+    });
+
+    it('set is a no-op (no throw, no save) without an active chat', () => {
+        mockChatMetadata = null;
+        expect(() => setSelectedLorebook('Book A')).not.toThrow();
+        expect(mockSaveMetadataDebounced).not.toHaveBeenCalled();
+    });
+});
+
+describe('migrateSelectedLorebook', () => {
+    it('copies legacy global selection when that book is active', () => {
+        extension_settings.tunnelvision = { selectedLorebook: 'Legacy Book' };
+        migrateSelectedLorebook(['Legacy Book', 'Other Book']);
+        expect(mockChatMetadata[SELECTED_BOOK_KEY]).toBe('Legacy Book');
+        expect(mockSaveMetadataDebounced).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not copy when the legacy book is not active', () => {
+        extension_settings.tunnelvision = { selectedLorebook: 'Legacy Book' };
+        migrateSelectedLorebook(['Other Book']);
+        expect(SELECTED_BOOK_KEY in mockChatMetadata).toBe(false);
+        expect(mockSaveMetadataDebounced).not.toHaveBeenCalled();
+    });
+
+    it('does not overwrite an existing chat selection', () => {
+        mockChatMetadata[SELECTED_BOOK_KEY] = 'Chat Book';
+        extension_settings.tunnelvision = { selectedLorebook: 'Legacy Book' };
+        migrateSelectedLorebook(['Legacy Book', 'Chat Book']);
+        expect(mockChatMetadata[SELECTED_BOOK_KEY]).toBe('Chat Book');
+        expect(mockSaveMetadataDebounced).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op without an active chat', () => {
+        mockChatMetadata = null;
+        extension_settings.tunnelvision = { selectedLorebook: 'Legacy Book' };
+        expect(() => migrateSelectedLorebook(['Legacy Book'])).not.toThrow();
+    });
+});

--- a/tools/remember.js
+++ b/tools/remember.js
@@ -169,7 +169,8 @@ Save entries to the lorebook where they belong based on the descriptions above. 
                     content: args.content,
                     comment: args.title,
                     keys: args.keys || [],
-                    nodeId: args.node_id || null,
+                    nodeId: args.node_id,
+                    tv_tracker: args.tv_tracker,
                 });
                 return `Saved memory: "${result.comment}" (UID ${result.uid}) → category "${result.nodeLabel}" in "${lorebook}".${dedupWarning}`;
             } catch (e) {

--- a/tools/search.js
+++ b/tools/search.js
@@ -19,6 +19,7 @@ import {
 } from '../tree-store.js';
 import { getReadableBooks } from '../tool-registry.js';
 import { getKeywordTriggeredUids } from '../index.js';
+import { getInjectedNodeIds } from '../sidecar-retrieval.js';
 
 // ─── Loop Detection ─────────────────────────────────────────────
 // Tracks node IDs called within the current generation turn.
@@ -385,6 +386,7 @@ function formatCollapsedNode(node, depth, isRoot = false, maxDepth = Infinity) {
  */
 async function resolveNodeEntries(nodeId, seenEntries = new Set()) {
     const results = [];
+    const seenPassages = new Set();
 
     // Document-level node: resolve all entries from that specific lorebook
     if (isDocNode(nodeId)) {
@@ -396,7 +398,7 @@ async function resolveNodeEntries(nodeId, seenEntries = new Set()) {
         const bookData = await loadWorldInfo(bookName);
         if (!bookData || !bookData.entries) return '';
         const uidMap = buildUidMap(bookData.entries);
-        pushResolvedEntries(results, seenEntries, bookName, uidMap, uids);
+        pushResolvedEntries(results, seenEntries, bookName, uidMap, uids, seenPassages);
         return results.join('\n\n');
     }
 
@@ -414,13 +416,28 @@ async function resolveNodeEntries(nodeId, seenEntries = new Set()) {
         if (!bookData || !bookData.entries) continue;
 
         const uidMap = buildUidMap(bookData.entries);
-        pushResolvedEntries(results, seenEntries, bookName, uidMap, uids);
+        pushResolvedEntries(results, seenEntries, bookName, uidMap, uids, seenPassages);
     }
 
     return results.join('\n\n');
 }
 
-function pushResolvedEntries(results, seenEntries, bookName, uidMap, uids) {
+function deduplicatePassages(content, seenPassages) {
+    if (!seenPassages) return content;
+    const passages = content.split(/(?<=[.!?])\s+(?=[A-Z"[])|(?:\n{2,})/)
+        .map(p => p.trim())
+        .filter(p => p.length > 0);
+    const unique = [];
+    for (const passage of passages) {
+        const key = passage.toLowerCase().replace(/[^\w\s]/g, ' ').replace(/\s+/g, ' ').trim();
+        if (key.length >= 40 && seenPassages.has(key)) continue;
+        if (key.length >= 40) seenPassages.add(key);
+        unique.push(passage);
+    }
+    return unique.join(' ').trim();
+}
+
+function pushResolvedEntries(results, seenEntries, bookName, uidMap, uids, seenPassages = null) {
     for (const uid of uids) {
         const entry = uidMap.get(uid);
         if (!entry?.content || entry.disable) continue;
@@ -431,7 +448,9 @@ function pushResolvedEntries(results, seenEntries, bookName, uidMap, uids) {
         const title = entry.comment || entry.key?.[0] || `Entry #${uid}`;
         const triggered = getKeywordTriggeredUids().has(Number(uid));
         const tag = triggered ? ' | ⚡ Already in context via keyword trigger' : '';
-        results.push(`[Lorebook: ${bookName} | UID: ${uid} | Title: ${title}${tag}]\n${entry.content}`);
+        const content = deduplicatePassages(entry.content, seenPassages);
+        if (!content) continue;
+        results.push(`[Lorebook: ${bookName} | UID: ${uid} | Title: ${title}${tag}]\n${content}`);
     }
 }
 
@@ -497,6 +516,7 @@ async function buildEntryManifest(nodeId) {
 async function resolveEntriesByUid(uids) {
     const results = [];
     const seen = new Set();
+    const seenPassages = new Set();
 
     for (const bookName of getReadableBooks()) {
         const bookData = await loadWorldInfo(bookName);
@@ -512,7 +532,9 @@ async function resolveEntriesByUid(uids) {
             if (seen.has(key)) continue;
             seen.add(key);
             const title = entry.comment || entry.key?.[0] || `Entry #${numUid}`;
-            results.push(`[Lorebook: ${bookName} | UID: ${numUid} | Title: ${title}]\n${entry.content}`);
+            const content = deduplicatePassages(entry.content, seenPassages);
+            if (!content) continue;
+            results.push(`[Lorebook: ${bookName} | UID: ${numUid} | Title: ${title}]\n${content}`);
         }
     }
 

--- a/tools/summarize.js
+++ b/tools/summarize.js
@@ -81,10 +81,6 @@ function getSummarizedHideRange(messagesBack, overrideStart, overrideEnd) {
         const watermark = getWatermark();
         if (watermark < 0) {
             // Watermark has never been set (first-ever summary in this chat).
-            // Refusing to hide because the fallback range would cover the entire
-            // chat from message 1, which is almost always wrong. The watermark
-            // will be set after this summary completes (line below), so future
-            // summaries will have a safe range.
             console.log('[TunnelVision] Skipping auto-hide: no watermark set yet (first summary in this chat). Setting watermark to current position.');
             setWatermark(currentMsgId - 1);
             return null;
@@ -338,6 +334,7 @@ When you notice related events forming a pattern or storyline, group them into "
                     comment: `[Summary] ${args.title}`,
                     keys,
                     nodeId: targetNodeId,
+                    tv_tracker: args.tv_tracker,
                 });
                 markAutoSummaryComplete();
                 let response = `Summarized: "${args.title}" (UID ${result.uid}) → "${result.nodeLabel}" in "${lorebook}". Significance: ${significance}.`;

--- a/tree-builder.js
+++ b/tree-builder.js
@@ -21,9 +21,9 @@ import {
     saveTree,
     getAllEntryUids,
     getSettings,
-    findConnectionProfile,
+    consolidateSiblingNodes,
 } from './tree-store.js';
-import { applyBackgroundPromptAddendum } from './agent-utils.js';
+import { applyBackgroundPromptAddendum, trigramSimilarity } from './agent-utils.js';
 
 /**
  * Granularity presets control how aggressively the builder splits entries.
@@ -91,45 +91,15 @@ async function generateRaw(opts) {
 }
 
 /**
- * Switch to the configured TV connection profile (if any), run the callback,
- * then restore the original profile. Falls back gracefully if Connection Manager
- * isn't installed or the /profile command isn't available.
- * @param {() => Promise<T>} fn Async function to run with the profile active
+ * Run a callback against TV's LLM. If the sidecar is configured, the callback makes
+ * direct API calls; otherwise it runs against ST's current active API (generateRaw).
+ * No connection-profile switching — TV no longer owns an ST profile.
+ * @param {() => Promise<T>} fn
  * @returns {Promise<T>}
  * @template T
  */
-async function withConnectionProfile(fn) {
-    // Sidecar makes direct API calls — no need to switch ST profiles
-    if (isSidecarConfigured()) return fn();
-
-    const settings = getSettings();
-    const targetProfile = findConnectionProfile(settings.connectionProfile);
-    const targetProfileName = targetProfile?.name || settings.connectionProfile;
-    if (!targetProfileName) {
-        return fn();
-    }
-
-    const profileCmd = getContext()?.SlashCommandParser?.commands?.['profile'];
-    if (!profileCmd) {
-        console.warn('[TunnelVision] /profile command not available (Connection Manager not loaded). Using current API.');
-        return fn();
-    }
-
-    // Capture the current profile name to restore later
-    const originalProfile = await profileCmd.callback({}, '');
-
-    // Skip switching if already on the target profile
-    if (originalProfile === targetProfileName) {
-        return fn();
-    }
-
-    try {
-        console.log(`[TunnelVision] Switching to connection profile: "${targetProfileName}"`);
-        await profileCmd.callback({ await: 'true', timeout: '5000' }, targetProfileName);
-        return await fn();
-    } finally {
-        await profileCmd.callback({ await: 'true', timeout: '5000' }, originalProfile || '<None>');
-    }
+async function withSidecarOrCurrentApi(fn) {
+    return fn();
 }
 
 /**
@@ -244,11 +214,13 @@ export async function buildTreeFromMetadata(lorebookName, options = {}) {
  * @returns {Promise<import('./tree-store.js').TreeIndex>}
  */
 export async function buildTreeWithLLM(lorebookName, options = {}) {
-    return withConnectionProfile(() => _buildTreeWithLLM(lorebookName, options));
+    return withSidecarOrCurrentApi(() => _buildTreeWithLLM(lorebookName, options));
 }
 
 /** Default max concurrent LLM calls during build phases. */
 const BUILD_CONCURRENCY = 3;
+
+const NODE_LABEL_FUZZY_THRESHOLD = 0.65;
 
 /**
  * Run an array of async tasks with bounded concurrency.
@@ -314,7 +286,7 @@ async function _buildTreeWithLLM(lorebookName, options = {}) {
     progress(`Categorizing chunk 1/${chunks.length}`, 0);
     detail_(`${activeEntries.length} entries across ${chunks.length} chunk(s)`);
     const allEntryManifest = chunks.length > 1
-        ? activeEntries.map(e => formatEntryForLLM(e, 'names')).join('\n  - ')
+        ? activeEntries.map(e => formatEntryForLLM(e, 'names', { includeUid: false })).join('\n  - ')
         : null;
     const firstPrompt = buildCategorizationPrompt(lorebookName, chunks[0], activeEntries.length, allEntryManifest);
     const firstResponse = await generateRaw({
@@ -324,7 +296,12 @@ async function _buildTreeWithLLM(lorebookName, options = {}) {
     if (!firstResponse) throw new Error('LLM returned empty response for tree categorization.');
 
     const allUids = activeEntries.map(e => e.uid);
-    const tree = await parseLLMTreeResponse(lorebookName, firstResponse, allUids);
+    // For multi-chunk builds, only pass chunk 1's UIDs to the initial parse.
+    // parseLLMTreeResponse's fallback assigns unplaced UIDs to root — if allUids
+    // is passed here, entries from chunks 2+ are pre-assigned to root before those
+    // chunks are even processed, causing mergeLLMResponse to skip them as "already assigned".
+    const chunk1Uids = chunks.length > 1 ? chunks[0].map(e => e.uid) : allUids;
+    const tree = await parseLLMTreeResponse(lorebookName, firstResponse, chunk1Uids);
 
     // Subsequent chunks: run in parallel — each gets the same category snapshot
     if (chunks.length > 1) {
@@ -361,6 +338,32 @@ async function _buildTreeWithLLM(lorebookName, options = {}) {
         if (!assigned.has(uid)) addEntryToNode(tree.root, uid);
     }
 
+    // Re-categorize any entries that couldn't be placed by the main chunking pass
+    if (tree.root.entryUids.length > 0) {
+        progress('Re-categorizing uncategorized entries…', 62);
+        const rootUids = [...tree.root.entryUids];
+        const rootUidSet = new Set(rootUids);
+        const rootEntries = activeEntries.filter(e => rootUidSet.has(e.uid));
+        const existingCategories = extractCategoryLabels(tree.root);
+        if (existingCategories.length > 0) {
+            console.log(`[TunnelVision] Re-categorizing ${rootEntries.length} uncategorized entries against ${existingCategories.length} categories…`);
+            const retryPrompt = buildContinuationPrompt(lorebookName, rootEntries, existingCategories, activeEntries.length);
+            const retryResponse = await generateRaw({
+                prompt: retryPrompt,
+                systemPrompt: applyBackgroundPromptAddendum('You are a categorization assistant. Respond ONLY with valid JSON, no commentary.'),
+            });
+            if (retryResponse) {
+                tree.root.entryUids = []; // clear so mergeLLMResponse can place them
+                mergeLLMResponse(tree, retryResponse, allUids);
+                const reassigned = new Set(getAllEntryUids(tree.root));
+                for (const uid of rootUids) {
+                    if (!reassigned.has(uid)) addEntryToNode(tree.root, uid);
+                }
+                console.log(`[TunnelVision] Re-categorization: placed ${rootUids.length - tree.root.entryUids.length}/${rootUids.length} previously uncategorized entries.`);
+            }
+        }
+    }
+
     // Save intermediate tree so chunking work isn't lost if subdivision/summaries abort
     tree.lastBuilt = Date.now();
     saveTree(lorebookName, tree);
@@ -370,6 +373,7 @@ async function _buildTreeWithLLM(lorebookName, options = {}) {
     progress('Subdividing large nodes…', 65);
     detail_(`Splitting categories with ${gran.maxEntries}+ entries (granularity: ${gran.label})`);
     await subdivideLargeNodes(tree.root, bookData, activeEntries.length);
+    consolidateSiblingNodes(tree.root);
     saveTree(lorebookName, tree);
 
     // PageIndex pattern: generate per-node summaries (parallel with batching)
@@ -430,9 +434,17 @@ function chunkEntries(entries, detail, charLimit) {
 function extractCategoryLabels(root) {
     const labels = [];
     for (const child of (root.children || [])) {
-        labels.push(child.label);
+        const count = getAllEntryUids(child).length;
+        const summary = child.summary ? ` — ${child.summary.split('\n')[0].slice(0, 80)}` : '';
+        labels.push(`${child.label} (${count} entries)${summary}`);
         for (const sub of (child.children || [])) {
-            labels.push(`${child.label} > ${sub.label}`);
+            const subCount = getAllEntryUids(sub).length;
+            const subSummary = sub.summary ? ` — ${sub.summary.split('\n')[0].slice(0, 60)}` : '';
+            labels.push(`  ${child.label} > ${sub.label} (${subCount} entries)${subSummary}`);
+            for (const grand of (sub.children || [])) {
+                const grandCount = getAllEntryUids(grand).length;
+                labels.push(`    ${child.label} > ${sub.label} > ${grand.label} (${grandCount} entries)`);
+            }
         }
     }
     return labels;
@@ -460,7 +472,7 @@ ${catList}
 Here are the NEW entries to categorize:
 ${entryList}
 
-IMPORTANT: Every entry UID must appear exactly once. Assign each entry to the BEST-FIT existing category. Only create a new category if an entry truly does not fit any existing one.${subCatHint} Do NOT leave entries uncategorized — every UID must be in a category.
+IMPORTANT: Every entry UID must appear exactly once. Strongly prefer existing categories — only create a new one if NO existing category is even a plausible fit. New category labels must follow the same naming style as existing ones (specific noun phrases, no "Other"/"Misc"/"General").${subCatHint} Do NOT leave entries uncategorized — every UID must be in a category.
 
 Respond with ONLY valid JSON in this exact format:
 {
@@ -483,6 +495,19 @@ Respond with ONLY valid JSON in this exact format:
  * @param {string} response
  * @param {number[]} validUids
  */
+function fuzzyFindNode(label, labelMap) {
+    if (labelMap.has(label)) return labelMap.get(label);
+    let best = null, bestScore = 0;
+    for (const [key, node] of labelMap) {
+        const score = trigramSimilarity(label, key);
+        if (score > bestScore && score >= NODE_LABEL_FUZZY_THRESHOLD) {
+            bestScore = score;
+            best = node;
+        }
+    }
+    return best;
+}
+
 function mergeLLMResponse(tree, response, validUids) {
     try {
         const jsonMatch = response.match(/\{[\s\S]*\}/);
@@ -504,7 +529,7 @@ function mergeLLMResponse(tree, response, validUids) {
 
         for (const cat of parsed.categories) {
             const catLabel = (cat.label || 'Unnamed').toLowerCase();
-            const existingNode = labelMap.get(catLabel);
+            const existingNode = fuzzyFindNode(catLabel, labelMap);
             const targetNode = existingNode || createTreeNode(cat.label || 'Unnamed', cat.summary || '');
 
             if (Array.isArray(cat.entries)) {
@@ -521,7 +546,7 @@ function mergeLLMResponse(tree, response, validUids) {
             if (Array.isArray(cat.children)) {
                 for (const sub of cat.children) {
                     const subLabel = (sub.label || 'Unnamed').toLowerCase();
-                    const existingSub = labelMap.get(subLabel);
+                    const existingSub = fuzzyFindNode(subLabel, labelMap);
                     const subNode = existingSub || createTreeNode(sub.label || 'Unnamed', sub.summary || '');
                     if (Array.isArray(sub.entries)) {
                         for (const uid of sub.entries) {
@@ -557,7 +582,7 @@ function mergeLLMResponse(tree, response, validUids) {
  */
 export async function generateSummariesForTree(node, lorebookName, _isRoot = true) {
     if (_isRoot) {
-        return withConnectionProfile(() => _generateSummariesForTree(node, lorebookName, true, null));
+        return withSidecarOrCurrentApi(() => _generateSummariesForTree(node, lorebookName, true, null));
     }
     return _generateSummariesForTree(node, lorebookName, _isRoot, null);
 }
@@ -747,11 +772,8 @@ async function subdivideLargeNodes(node, bookData, totalEntryCount = 0, _depth =
             // When the node already has children (e.g. root with orphaned entries from
             // multi-chunk categorization), tell the LLM about existing categories so it
             // can assign entries to them rather than creating redundant new ones.
-            const existingChildren = node.children.length > 0
-                ? node.children.map(c => c.label)
-                : [];
-            const existingHint = existingChildren.length > 0
-                ? `\n\nExisting sub-categories in "${node.label}": ${existingChildren.join(', ')}. Assign entries to these when they fit, or create new sub-categories for entries that don't fit any existing one.`
+            const existingHint = node.children.length > 0
+                ? `\n\nExisting sub-categories in "${node.label}": ${node.children.map(c => `${c.label} (${c.entryUids.length} entries)`).join(', ')}. Assign entries to these when they fit, or create new sub-categories only for entries that genuinely do not fit any existing one.`
                 : '';
 
             try {
@@ -759,7 +781,7 @@ async function subdivideLargeNodes(node, bookData, totalEntryCount = 0, _depth =
                 const subCatCount = Math.min(6, Math.ceil(nodeEntries.length / gran.maxEntries));
                 const entryList = nodeEntries.map(e => `  ${formatEntryForLLM(e, detail)}`).join('\n');
                 const response = await generateRaw({
-                    prompt: `You have ${nodeEntries.length} lorebook entries in "${node.label}". Split into 2-${subCatCount} sub-categories. Every entry must be assigned.${existingHint}\n\nEntries:\n${entryList}\n\nRespond ONLY with JSON: { "subcategories": [{ "label": "Name", "entries": [uid1, uid2] }] }`,
+                    prompt: `You have ${nodeEntries.length} lorebook entries in the "${node.label}" category of a lorebook tree used for AI context retrieval. Split into 2–${subCatCount} focused sub-categories so an AI assistant can navigate to the right entries quickly.${existingHint}\n\nUse specific, descriptive noun phrases as sub-category labels. Avoid "Other", "Miscellaneous", or "General". Every entry must be assigned to exactly one sub-category.\n\nEntries:\n${entryList}\n\nRespond ONLY with JSON: { "subcategories": [{ "label": "Name", "entries": [uid1, uid2] }] }`,
                     systemPrompt: applyBackgroundPromptAddendum('You are a categorization assistant. Respond ONLY with valid JSON, no commentary.'),
                 });
                 if (response) {
@@ -777,8 +799,9 @@ async function subdivideLargeNodes(node, bookData, totalEntryCount = 0, _depth =
                             for (const sub of parsed.subcategories) {
                                 const subLabel = (sub.label || 'Unnamed').toLowerCase();
                                 // Merge into existing child if label matches
-                                const target = childMap.get(subLabel) || createTreeNode(sub.label || 'Unnamed', '');
-                                const isNew = !childMap.has(subLabel);
+                                const existingChild = fuzzyFindNode(subLabel, childMap);
+                                const target = existingChild || createTreeNode(sub.label || 'Unnamed', '');
+                                const isNew = !existingChild;
 
                                 if (Array.isArray(sub.entries)) {
                                     for (const uid of sub.entries) {
@@ -829,6 +852,8 @@ ${entryList}
 
 Create a JSON hierarchy that groups these entries into logical categories. Use ${gran.targetCategories} top-level categories, each with sub-categories where natural. Aim for no more than ${gran.maxEntries} entries per leaf node. Every entry UID listed above must appear exactly once. Do NOT leave entries uncategorized.
 
+The tree is navigated by an AI assistant during chat to retrieve relevant context. Use specific, descriptive noun phrases as labels (e.g. "Magic System", "Elena's Backstory", "Port Alara Geography"). Avoid generic labels like "Other", "Miscellaneous", or "General". Category summaries should describe what an AI would find inside, not just restate the label.
+
 Respond with ONLY valid JSON in this exact format:
 {
   "categories": [
@@ -871,7 +896,7 @@ async function parseLLMTreeResponse(lorebookName, response, entryUids) {
                     }
                 }
                 if (Array.isArray(cat.children) && cat.children.length > 0) buildNodes(cat.children, node);
-                parent.children.push(node);
+                if (node.entryUids.length > 0 || node.children.length > 0) parent.children.push(node);
             }
         }
 
@@ -903,7 +928,7 @@ async function parseLLMTreeResponse(lorebookName, response, entryUids) {
  * @returns {Promise<{created: number, errors: number}>}
  */
 export async function ingestChatMessages(lorebookName, options) {
-    return withConnectionProfile(() => _ingestChatMessages(lorebookName, options));
+    return withSidecarOrCurrentApi(() => _ingestChatMessages(lorebookName, options));
 }
 
 async function _ingestChatMessages(lorebookName, { from, to, progress, detail }) {
@@ -948,6 +973,21 @@ async function _ingestChatMessages(lorebookName, { from, to, progress, detail })
 
     report(`Extracting facts from ${chunks.length} chunk(s)...`, 5);
 
+    // Load existing lorebook entries to prevent re-extraction and for trigram dedup
+    const existingBookData = await loadWorldInfo(lorebookName);
+    const existingTitles = [];
+    const dedupTexts = [];
+    if (existingBookData?.entries) {
+        for (const e of Object.values(existingBookData.entries)) {
+            if (e.disable) continue;
+            const title = (e.comment || '').trim();
+            if (title) existingTitles.push(title);
+            dedupTexts.push(`${e.comment || ''} ${e.content || ''}`.toLowerCase());
+        }
+    }
+    const shownExistingTitles = existingTitles.slice(0, 150);
+    const prevExtracted = []; // titles extracted from earlier chunks, passed to subsequent prompts
+
     let totalCreated = 0;
     let totalErrors = 0;
 
@@ -961,7 +1001,7 @@ async function _ingestChatMessages(lorebookName, { from, to, progress, detail })
         let response;
         try {
             response = await generateRaw({
-                prompt: buildIngestPrompt(lorebookName, formatted),
+                prompt: buildIngestPrompt(lorebookName, formatted, shownExistingTitles, [...prevExtracted]),
                 systemPrompt: applyBackgroundPromptAddendum('You are a fact extraction assistant. Extract important facts, character details, relationships, events, and world information from roleplay chat logs. Respond ONLY with valid JSON, no commentary.'),
             });
         } catch (e) {
@@ -993,9 +1033,15 @@ async function _ingestChatMessages(lorebookName, { from, to, progress, detail })
 
         if (!Array.isArray(entries)) continue;
 
-        // Create entries
+        // Create entries (with trigram dedup against existing and already-ingested entries)
         for (const extracted of entries) {
             if (!extracted.title || !extracted.content) continue;
+            const newText = `${extracted.title} ${extracted.content}`.toLowerCase();
+            const isDupe = dedupTexts.some(existing => trigramSimilarity(newText, existing) >= 0.62);
+            if (isDupe) {
+                console.log(`[TunnelVision] Ingest: skipping duplicate "${extracted.title}"`);
+                continue;
+            }
             try {
                 await createEntry(lorebookName, {
                     content: String(extracted.content).trim(),
@@ -1003,6 +1049,8 @@ async function _ingestChatMessages(lorebookName, { from, to, progress, detail })
                     keys: Array.isArray(extracted.keys) ? extracted.keys : [],
                     nodeId: null,
                 });
+                dedupTexts.push(newText);
+                prevExtracted.push(String(extracted.title).trim());
                 totalCreated++;
             } catch (e) {
                 console.warn(`[TunnelVision] Failed to create entry "${extracted.title}":`, e);
@@ -1016,10 +1064,26 @@ async function _ingestChatMessages(lorebookName, { from, to, progress, detail })
     return { created: totalCreated, errors: totalErrors };
 }
 
-function buildIngestPrompt(lorebookName, chatText) {
-    return `Extract important facts from this roleplay chat log for the lorebook "${lorebookName}".
+function buildIngestPrompt(lorebookName, chatText, existingTitles = [], prevExtracted = []) {
+    const existingSection = existingTitles.length > 0
+        ? `\n[Already in lorebook — do NOT re-extract these]\n${existingTitles.map(t => `- ${t}`).join('\n')}\n`
+        : '';
+    const prevSection = prevExtracted.length > 0
+        ? `\n[Already extracted from earlier chunks — do NOT duplicate these]\n${prevExtracted.map(t => `- ${t}`).join('\n')}\n`
+        : '';
 
+    return `Extract important facts from this roleplay chat log for the lorebook "${lorebookName}".
+${existingSection}${prevSection}
 For each distinct fact, character detail, relationship, event, or world detail, create an entry.
+
+Rules:
+- Extract ONLY concrete facts, not dialogue or opinions
+- Write content in third person, factual style
+- Each entry should be a single, distinct piece of information
+- Include character names in keys for cross-referencing
+- Skip trivial or generic information
+- Merge related facts into single entries when they belong together
+- If a subject already appears in the "Already in lorebook" list above, write content as an addendum — state only the new specific detail, do NOT restate who they are or repeat their general description
 
 Chat log:
 ${chatText}
@@ -1028,18 +1092,12 @@ Respond with ONLY a JSON array:
 [
   {
     "title": "Short descriptive title",
-    "content": "The factual information written in third person. Include names, places, details.",
-    "keys": ["keyword1", "keyword2"]
+    "content": "The factual information written in third person.",
+    "keys": ["keyword1", "keyword2"],
+    "significance": "low" | "medium" | "high",
+    "when": "approximate story time if discernible, otherwise omit this field"
   }
-]
-
-Rules:
-- Extract ONLY concrete facts, not dialogue or opinions
-- Write content in third person, factual style
-- Each entry should be a single, distinct piece of information
-- Include character names in keys for cross-referencing
-- Skip trivial or generic information
-- Merge related facts into single entries when they belong together`;
+]`;
 }
 
 function findBalancedJsonEnd(text, start, opener, closer) {

--- a/tree-store.js
+++ b/tree-store.js
@@ -6,7 +6,9 @@
 
 import { extension_settings } from '../../../extensions.js';
 import { saveSettingsDebounced } from '../../../../script.js';
+import { getContext } from '../../../st-context.js';
 import { loadWorldInfo } from '../../../world-info.js';
+import { trigramSimilarity } from './agent-utils.js';
 
 const EXTENSION_NAME = 'tunnelvision';
 const TRACKER_TITLE_PREFIX = /^\[tracker[^\]]*\]/i;
@@ -271,11 +273,8 @@ export const SETTING_DEFAULTS = {
     globalEnabled: true,
     trees: {},
     enabledLorebooks: {},
-    selectedLorebook: null,
+    selectedLorebook: null, // DEPRECATED: migration source only; selection now lives in chat_metadata
     bookDescriptions: {},
-    connectionProfile: null,
-    sidecarTemperature: 0.2,
-    sidecarMaxTokens: 8192,
     disabledTools: {},
     searchMode: 'traversal',
     collapsedDepth: 2,
@@ -310,6 +309,24 @@ export const SETTING_DEFAULTS = {
     backgroundPromptAddendum: '',
     confirmTools: {},
     toolPromptOverrides: {},
+    // Sidecar LLM — self-contained direct-API config (issue #29: own key, no allowKeysExposure)
+    sidecarProfile: {
+        enabled: false,
+        endpoint: '',       // e.g. https://api.openai.com/v1
+        apiKey: '',         // plaintext; only this key is at risk, not all ST keys
+        model: '',
+        format: 'openai',   // 'openai' | 'anthropic' | 'google'
+        maxTokens: 1000,
+        temperature: 0.3,
+    },
+    // Embedding sidecar — separate endpoint for vector dedup / similarity
+    embeddingProfile: {
+        enabled: false,
+        endpoint: '',
+        apiKey: '',         // may be empty for local endpoints
+        model: '',
+        format: 'openai',   // 'openai' | 'google' | 'gemini'
+    },
     // Sidecar auto-retrieval (pre-gen)
     sidecarAutoRetrieval: false,
     sidecarContextMessages: 10,
@@ -364,8 +381,21 @@ function ensureSettings() {
         didMutate = true;
     }
 
-    if (normalizeConnectionProfileSetting(s)) {
+    // Migration (issue #29): old connectionProfile-based sidecar is gone. Drop the
+    // stale setting and tell the user once to re-enter their key in the new fields.
+    if (Object.prototype.hasOwnProperty.call(s, 'connectionProfile')) {
+        delete s.connectionProfile;
         didMutate = true;
+        try {
+            if (!localStorage.getItem('tv_sidecar_migration_notified')) {
+                localStorage.setItem('tv_sidecar_migration_notified', '1');
+                toastr?.info(
+                    'TunnelVision sidecar now uses its own API key — re-enter it under TunnelVision settings → Sidecar LLM.',
+                    'TunnelVision',
+                    { timeOut: 12000 },
+                );
+            }
+        } catch { /* localStorage/toastr may be unavailable */ }
     }
 
     for (const [bookName, tree] of Object.entries(s.trees || {})) {
@@ -382,6 +412,76 @@ function ensureSettings() {
 export function getSettings() {
     ensureSettings();
     return extension_settings[EXTENSION_NAME];
+}
+
+function deduplicateUidsAcrossTree(node) {
+    let mutated = false;
+    for (const child of (node.children || [])) {
+        if (deduplicateUidsAcrossTree(child)) mutated = true;
+    }
+    if (node.children && node.children.length > 0) {
+        const descendantUids = new Set();
+        for (const child of node.children) {
+            for (const uid of getAllEntryUids(child)) descendantUids.add(uid);
+        }
+        const before = node.entryUids.length;
+        node.entryUids = node.entryUids.filter(uid => !descendantUids.has(uid));
+        if (node.entryUids.length !== before) mutated = true;
+    }
+    return mutated;
+}
+
+export function consolidateSiblingNodes(node, labelThreshold = 0.65, containThreshold = 0.60) {
+    let absorbed = 0;
+
+    for (const child of (node.children || [])) {
+        absorbed += consolidateSiblingNodes(child, labelThreshold, containThreshold);
+    }
+
+    const children = node.children;
+    if (!children || children.length < 2) return absorbed;
+
+    const toAbsorb = new Set();
+    for (let i = 0; i < children.length; i++) {
+        if (toAbsorb.has(i)) continue;
+        for (let j = i + 1; j < children.length; j++) {
+            if (toAbsorb.has(j)) continue;
+
+            const labelSim = trigramSimilarity(
+                children[i].label.toLowerCase(),
+                children[j].label.toLowerCase(),
+            );
+
+            const uidsI = new Set(getAllEntryUids(children[i]));
+            const uidsJ = new Set(getAllEntryUids(children[j]));
+            const smaller = uidsI.size <= uidsJ.size ? uidsI : uidsJ;
+            const larger  = uidsI.size <= uidsJ.size ? uidsJ : uidsI;
+            const containment = smaller.size >= 2
+                ? [...smaller].filter(u => larger.has(u)).length / smaller.size
+                : 0;
+
+            if (labelSim < labelThreshold && containment < containThreshold) continue;
+
+            const wi = uidsI.size >= uidsJ.size ? i : j;
+            const li = wi === i ? j : i;
+
+            for (const uid of children[li].entryUids) {
+                if (!children[wi].entryUids.includes(uid)) {
+                    children[wi].entryUids.push(uid);
+                }
+            }
+            children[wi].children.push(...(children[li].children || []));
+            toAbsorb.add(li);
+            absorbed++;
+        }
+    }
+
+    if (toAbsorb.size > 0) {
+        node.children = children.filter((_, idx) => !toAbsorb.has(idx));
+        absorbed += consolidateSiblingNodes(node, labelThreshold, containThreshold);
+    }
+
+    return absorbed;
 }
 
 function normalizeTree(tree, lorebookName) {
@@ -409,6 +509,10 @@ function normalizeTree(tree, lorebookName) {
     }
 
     if (normalizeTreeNode(tree.root)) {
+        mutated = true;
+    }
+
+    if (deduplicateUidsAcrossTree(tree.root)) {
         mutated = true;
     }
 
@@ -487,29 +591,6 @@ function normalizeTrackerSettings(settings) {
     return mutated;
 }
 
-function normalizeConnectionProfileSetting(settings) {
-    const current = settings.connectionProfile;
-    if (!current || typeof current !== 'string') return false;
-
-    const profiles = getConnectionProfiles();
-    if (profiles.some(profile => profile.id === current)) {
-        return false;
-    }
-
-    const legacyMatch = profiles.find(profile => profile.name === current);
-    if (legacyMatch) {
-        settings.connectionProfile = legacyMatch.id;
-        return true;
-    }
-
-    return false;
-}
-
-function getConnectionProfiles() {
-    const profiles = extension_settings?.connectionManager?.profiles;
-    return Array.isArray(profiles) ? profiles : [];
-}
-
 function resolveEntriesMap(entriesOrBookData) {
     if (!entriesOrBookData || typeof entriesOrBookData !== 'object') return null;
     if (entriesOrBookData.entries && typeof entriesOrBookData.entries === 'object') {
@@ -534,42 +615,44 @@ function storeTrackerSet(bookName, trackerSet) {
     }
 }
 
+const SELECTED_BOOK_KEY = 'tunnelvision_selected_book';
+
 export function getSelectedLorebook() {
-    const settings = getSettings();
-    return settings.selectedLorebook || null;
+    try {
+        return getContext().chatMetadata?.[SELECTED_BOOK_KEY] || null;
+    } catch {
+        return null; // no active chat
+    }
 }
 
 export function setSelectedLorebook(lorebookName) {
-    const settings = getSettings();
-    settings.selectedLorebook = lorebookName || null;
-    saveSettingsDebounced();
+    try {
+        const context = getContext();
+        if (!context.chatMetadata) return; // no active chat
+        if (lorebookName) {
+            context.chatMetadata[SELECTED_BOOK_KEY] = lorebookName;
+        } else {
+            delete context.chatMetadata[SELECTED_BOOK_KEY];
+        }
+        context.saveMetadataDebounced?.();
+    } catch {
+        /* no active chat — no-op */
+    }
 }
 
-export function getConnectionProfileId() {
-    const settings = getSettings();
-    return settings.connectionProfile || null;
-}
-
-export function setConnectionProfileId(profileId) {
-    const settings = getSettings();
-    settings.connectionProfile = profileId || null;
-    saveSettingsDebounced();
-}
-
-export function findConnectionProfile(profileRef = null) {
-    const ref = profileRef ?? getConnectionProfileId();
-    if (!ref) return null;
-
-    const profiles = getConnectionProfiles();
-    return profiles.find(profile => profile.id === ref || profile.name === ref) || null;
-}
-
-export function getConnectionProfileName(profileRef = null) {
-    return findConnectionProfile(profileRef)?.name || null;
-}
-
-export function listConnectionProfiles() {
-    return [...getConnectionProfiles()];
+export function migrateSelectedLorebook(activeBooks) {
+    try {
+        const context = getContext();
+        if (!context.chatMetadata) return;           // no active chat
+        if (context.chatMetadata[SELECTED_BOOK_KEY]) return; // chat already chose
+        const legacy = getSettings().selectedLorebook;
+        if (legacy && Array.isArray(activeBooks) && activeBooks.includes(legacy)) {
+            context.chatMetadata[SELECTED_BOOK_KEY] = legacy;
+            context.saveMetadataDebounced?.();
+        }
+    } catch {
+        /* no active chat — skip */
+    }
 }
 
 // ─── Per-Lorebook Permissions ────────────────────────────────────

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -28,9 +28,6 @@ import {
     isTrackerTitle,
     setTrackerUid,
     syncTrackerUidsForLorebook,
-    getConnectionProfileId,
-    setConnectionProfileId,
-    listConnectionProfiles,
     getBookPermission,
     setBookPermission,
     getBookInjectionMode,
@@ -38,6 +35,7 @@ import {
     SETTING_DEFAULTS,
 } from './tree-store.js';
 import { buildTreeFromMetadata, buildTreeWithLLM, generateSummariesForTree, ingestChatMessages } from './tree-builder.js';
+import { testSidecarConnectivity, testEmbeddingConnectivity } from './llm-sidecar.js';
 import { registerTools, unregisterTools, getDefaultToolDescriptions, stripDynamicContent } from './tool-registry.js';
 import { runDiagnostics } from './diagnostics.js';
 import { applyRecurseLimit } from './index.js';
@@ -47,6 +45,7 @@ import { callGenericPopup, POPUP_TYPE } from '../../../popup.js';
 
 
 let currentLorebook = null;
+let activeEditorRefresh = null;
 
 function selectCurrentLorebook(bookName) {
     currentLorebook = bookName || null;
@@ -54,16 +53,13 @@ function selectCurrentLorebook(bookName) {
 }
 
 function syncSelectedLorebook() {
-    if (currentLorebook && world_names?.includes(currentLorebook)) {
+    // Chat-stored selection is authoritative — do not keep a stale currentLorebook
+    // across a chat switch even if the old book still exists in world_names.
+    const stored = getSelectedLorebook();
+    if (stored && world_names?.includes(stored)) {
+        currentLorebook = stored;
         return;
     }
-
-    const preferredLorebook = getSelectedLorebook();
-    if (preferredLorebook && world_names?.includes(preferredLorebook)) {
-        currentLorebook = preferredLorebook;
-        return;
-    }
-
     currentLorebook = null;
 }
 
@@ -190,8 +186,20 @@ export function bindUIEvents() {
     // Multi-book mode
     $('input[name="tv_multi_book_mode"]').on('change', onMultiBookModeChange);
 
-    // Sidecar LLM (connection profile + sampler overrides)
-    $('#tv_connection_profile').on('change', onConnectionProfileChange);
+    // Sidecar LLM direct-config fields
+    $('#tv_sidecar_enabled').on('change', onSidecarProfileChange);
+    $('#tv_sidecar_endpoint').on('input', onSidecarProfileChange);
+    $('#tv_sidecar_format').on('change', onSidecarProfileChange);
+    $('#tv_sidecar_api_key').on('input', onSidecarProfileChange);
+    $('#tv_sidecar_model').on('input', onSidecarProfileChange);
+    $('#tv_sidecar_test').on('click', onTestSidecarConnection);
+    // Embedding sidecar fields
+    $('#tv_embedding_enabled').on('change', onEmbeddingProfileChange);
+    $('#tv_embedding_endpoint').on('input', onEmbeddingProfileChange);
+    $('#tv_embedding_format').on('change', onEmbeddingProfileChange);
+    $('#tv_embedding_api_key').on('input', onEmbeddingProfileChange);
+    $('#tv_embedding_model').on('input', onEmbeddingProfileChange);
+    $('#tv_embedding_test').on('click', onTestEmbeddingConnection);
     $('#tv_sidecar_temperature').on('input', onSidecarTemperatureChange);
     $('#tv_sidecar_max_tokens').on('input', onSidecarMaxTokensChange);
 
@@ -238,6 +246,11 @@ export function refreshUI() {
     const settings = getSettings();
     const globalEnabled = settings.globalEnabled !== false;
     syncSelectedLorebook();
+
+    // Trigger active editor refresh if open
+    if (activeEditorRefresh) {
+        activeEditorRefresh();
+    }
 
     $('#tv_global_enabled').prop('checked', globalEnabled);
     $('#tv_main_controls').toggle(globalEnabled);
@@ -340,8 +353,8 @@ export function refreshUI() {
     // Sync multi-book mode
     $(`input[name="tv_multi_book_mode"][value="${settings.multiBookMode || 'unified'}"]`).prop('checked', true);
 
-    // Sync connection profile + sidecar sampler controls
-    populateConnectionProfiles();
+    // Sync sidecar/embedding profiles + sampler controls
+    populateSidecarProfiles();
 
     populateLorebookDropdown();
     $('#tv_lorebook_controls').toggle(!!currentLorebook);
@@ -943,23 +956,69 @@ function onMultiBookModeChange() {
 
 // ─── Sidecar LLM (Connection Profile + Sampler Overrides) ───────
 
-function onConnectionProfileChange() {
-    setConnectionProfileId($(this).val() || null);
-    // Show/hide sampler controls when a profile is selected
-    $('#tv_sidecar_sampler_fields').toggle(!!$(this).val());
+function readSidecarProfileFromUi(settings) {
+    const p = settings.sidecarProfile || (settings.sidecarProfile = {});
+    p.enabled = $('#tv_sidecar_enabled').prop('checked');
+    p.endpoint = $('#tv_sidecar_endpoint').val() || '';
+    p.format = $('#tv_sidecar_format').val() || 'openai';
+    p.apiKey = $('#tv_sidecar_api_key').val() || '';
+    p.model = $('#tv_sidecar_model').val() || '';
+    if (typeof p.maxTokens !== 'number') p.maxTokens = 1000;
+    if (typeof p.temperature !== 'number') p.temperature = 0.3;
+    return p;
+}
+
+function onSidecarProfileChange() {
+    const settings = getSettings();
+    readSidecarProfileFromUi(settings);
+    $('#tv_sidecar_sampler_fields').toggle(!!settings.sidecarProfile.enabled);
+    saveSettingsDebounced();
+}
+
+function onEmbeddingProfileChange() {
+    const settings = getSettings();
+    const p = settings.embeddingProfile || (settings.embeddingProfile = {});
+    p.enabled = $('#tv_embedding_enabled').prop('checked');
+    p.endpoint = $('#tv_embedding_endpoint').val() || '';
+    p.format = $('#tv_embedding_format').val() || 'openai';
+    p.apiKey = $('#tv_embedding_api_key').val() || '';
+    p.model = $('#tv_embedding_model').val() || '';
+    saveSettingsDebounced();
+}
+
+async function onTestSidecarConnection() {
+    const $btn = $('#tv_sidecar_test');
+    $btn.prop('disabled', true).text('Testing…');
+    try {
+        const result = await testSidecarConnectivity();
+        (result.ok ? toastr.success : toastr.error)(result.message, 'Sidecar LLM');
+    } finally {
+        $btn.prop('disabled', false).text('Test Connection');
+    }
+}
+
+async function onTestEmbeddingConnection() {
+    const $btn = $('#tv_embedding_test');
+    $btn.prop('disabled', true).text('Testing…');
+    try {
+        const result = await testEmbeddingConnectivity();
+        (result.ok ? toastr.success : toastr.error)(result.message, 'Embedding Sidecar');
+    } finally {
+        $btn.prop('disabled', false).text('Test Connection');
+    }
 }
 
 function onSidecarTemperatureChange() {
     const val = parseFloat($(this).val());
     const settings = getSettings();
-    settings.sidecarTemperature = val;
+    (settings.sidecarProfile || (settings.sidecarProfile = {})).temperature = val;
     $('#tv_sidecar_temp_val').text(val.toFixed(2));
     saveSettingsDebounced();
 }
 
 function onSidecarMaxTokensChange() {
     const settings = getSettings();
-    settings.sidecarMaxTokens = Number($(this).val()) || 2048;
+    (settings.sidecarProfile || (settings.sidecarProfile = {})).maxTokens = Number($(this).val()) || 1000;
     saveSettingsDebounced();
 }
 
@@ -1022,26 +1081,25 @@ function onBookInjectionModeChange() {
     registerTools();
 }
 
-function populateConnectionProfiles() {
-    const $select = $('#tv_connection_profile');
-    const currentVal = getConnectionProfileId() || '';
-
-    // Keep the first option (default)
-    $select.find('option:not(:first)').remove();
-
-    for (const profile of listConnectionProfiles().sort((a, b) => (a.name || '').localeCompare(b.name || ''))) {
-        if (!profile?.id || !profile?.name) continue;
-        $select.append($('<option></option>').val(profile.id).text(profile.name));
-    }
-
-    $select.val(currentVal);
-
-    // Sync sampler controls
+function populateSidecarProfiles() {
     const settings = getSettings();
-    $('#tv_sidecar_temperature').val(settings.sidecarTemperature ?? 0.2);
-    $('#tv_sidecar_temp_val').text((settings.sidecarTemperature ?? 0.2).toFixed(2));
-    $('#tv_sidecar_max_tokens').val(settings.sidecarMaxTokens || 2048);
-    $('#tv_sidecar_sampler_fields').toggle(!!currentVal);
+    const sc = settings.sidecarProfile || {};
+    $('#tv_sidecar_enabled').prop('checked', !!sc.enabled);
+    $('#tv_sidecar_endpoint').val(sc.endpoint || '');
+    $('#tv_sidecar_format').val(sc.format || 'openai');
+    $('#tv_sidecar_api_key').val(sc.apiKey || '');
+    $('#tv_sidecar_model').val(sc.model || '');
+    $('#tv_sidecar_temperature').val(sc.temperature ?? 0.3);
+    $('#tv_sidecar_temp_val').text((sc.temperature ?? 0.3).toFixed(2));
+    $('#tv_sidecar_max_tokens').val(sc.maxTokens || 1000);
+    $('#tv_sidecar_sampler_fields').toggle(!!sc.enabled);
+
+    const emb = settings.embeddingProfile || {};
+    $('#tv_embedding_enabled').prop('checked', !!emb.enabled);
+    $('#tv_embedding_endpoint').val(emb.endpoint || '');
+    $('#tv_embedding_format').val(emb.format || 'openai');
+    $('#tv_embedding_api_key').val(emb.apiKey || '');
+    $('#tv_embedding_model').val(emb.model || '');
 
     // Sync auto-retrieval controls
     const autoRetrieval = settings.sidecarAutoRetrieval === true;
@@ -1138,6 +1196,24 @@ async function onOpenTreeEditor() {
         renderTreeNodes();
         renderMainPanel();
     }
+
+    // Automatic refresh logic
+    activeEditorRefresh = async () => {
+        const freshBookData = await loadWorldInfo(bookName);
+        entryLookup = buildEntryLookup(freshBookData);
+        // Sync tree in case it was modified externally
+        const freshTree = getTree(bookName);
+        if (freshTree) {
+            // Update the local tree reference's root
+            tree.root = freshTree.root;
+            // If the selected node no longer exists in the new tree, fall back to root
+            if (selectedNode && selectedNode.id !== '__unassigned__' && !findNodeById(tree.root, selectedNode.id)) {
+                selectedNode = tree.root;
+            }
+        }
+        renderTreeNodes();
+        renderMainPanel();
+    };
 
     function isRootNode(node) {
         return !!node && node.id === tree.root.id;
@@ -1441,6 +1517,10 @@ async function onOpenTreeEditor() {
                 const wasTracked = isTrackerUid(bookName, uid);
                 entry.disable = !entry.disable;
                 await saveWorldInfo(bookName, bookData, true);
+                
+                // Update local lookup to ensure countActiveEntries stays correct
+                entryLookup[uid] = entry;
+
                 if (entry.disable) {
                     setTrackerUid(bookName, uid, false);
                 } else if (wasTracked || isTrackerTitle(entry.comment)) {
@@ -1760,12 +1840,16 @@ async function onOpenTreeEditor() {
     });
 
     // Show popup (blocks until user closes it)
-    await callGenericPopup($popup, POPUP_TYPE.DISPLAY, '', {
-        large: true,
-        wide: true,
-        allowVerticalScrolling: true,
-        allowHorizontalScrolling: false,
-    });
+    try {
+        await callGenericPopup($popup, POPUP_TYPE.DISPLAY, '', {
+            large: true,
+            wide: true,
+            allowVerticalScrolling: true,
+            allowHorizontalScrolling: false,
+        });
+    } finally {
+        activeEditorRefresh = null;
+    }
 
     // When popup closes, refresh sidebar UI
     loadLorebookUI(bookName);


### PR DESCRIPTION
## Summary

Five self-contained improvements developed in the [mozophe/TunnelVision](https://github.com/mozophe/TunnelVision) fork, bundled into one PR and rebased onto current upstream `main`. They are grouped here rather than split because they share eight core files with interleaved edits (see *Why one PR* below).

## What's in it

### 🔐 Self-contained sidecar / embedding API config
The background **sidecar LLM** and the **embedding** engine now carry their own endpoint / key / model / format instead of reading SillyTavern's secrets store. This removes the need for `allowKeysExposure: true` in `config.yaml` — which otherwise exposes *every* stored key to any frontend code. Two independent profiles (Sidecar LLM, Embedding), each with a **Test Connection** button and sampler controls (default temp `0.3`, max tokens `1000`).
- Rewrites `llm-sidecar.js`; drops the connection-profile switching path in `tree-builder.js` / `tree-store.js`; diagnostics validate the new profiles.

### 📒 Per-chat lorebook selection
Lorebook selection is stored in `chat_metadata` instead of one global setting, so it travels per chat and no longer leaks across characters. Legacy global selections migrate automatically on chat change (`migrateSelectedLorebook`), guarded so a stale cross-character book is never copied.

### ↩️ Resilient undo & cleanup + native keyword tracking
Every sidecar write is captured as a **per-turn snapshot** persisted to chat metadata. On edit / delete / swipe, TunnelVision keeps the lorebook consistent with the visible chat: updates the sidecar made to existing entries **revert**, and entries it **created** for now-deleted messages are removed (lorebook + tree restore on chat deletion). Snapshots survive page reload / chat switch. Sidecar-created entries are tracked via **native ST keywords (`tv_tracker`)** for reliable identification and clean UI / slash-command sync. *(These two were developed as one system — the keyword tracking is the mechanism the cleanup uses to find its entries — so they can't be meaningfully separated.)*

### 📊 Activity feed
Deterministic **newest-first** ordering, per-node retrieval rows (see exactly which entries were pulled), and snapshot-revert logging.

### 🧠 Dedup & summary quality
Duplicate summary detection **updates** the existing entry instead of skipping; node consolidation + fuzzy matching for category nodes during tree build; hardened summary prompts + dedup threshold; fixes for summary spam and entries landing in the tree root.

## How to review

Because features share files, reviewing **per file** is cleaner than per commit:

| Area | Primary files |
|------|---------------|
| Sidecar API config | `llm-sidecar.js`, `diagnostics.js`, `settings.html`, `tree-store.js` (profile accessors), `tree-builder.js` (`withSidecarOrCurrentApi`) |
| Per-chat lorebook | `tree-store.js` (selection), `ui-controller.js`, `index.js` (`onChatChanged`) |
| Undo/cleanup + keywords | `sidecar-writer.js`, `index.js`, `entry-manager.js`, `tools/summarize.js`, `tools/remember.js` |
| Activity feed | `activity-feed.js`, `sidecar-retrieval.js` |
| Dedup & summaries | `commands.js`, `tree-builder.js`, `constants.js`, `sidecar-writer.js` |

### Conflict resolution against current upstream (Raya integration)
Three files conflicted when rebasing onto current `main`; resolutions:
- **`index.js` `onChatChanged`** — kept upstream's `refreshRuntimeState('chat changed')` refactor for the trailing `refreshUI` + guarded `registerTools`, and layered the feature hooks in front of it. **Ordering matters:** `autoDetectLorebooks()` runs *first* (it enables pattern-matched lorebooks, mutating the active-book set), so the subsequent `migrateSelectedLorebook(getActiveTunnelVisionBooks())` sees the auto-detected books — preserving the pre-rebase order `autoDetect → hydrateSnapshots → migrate → cleanInvalidSidecarMemories → refreshUI/registerTools`. (`refreshRuntimeState` re-runs `autoDetectLorebooks` internally, which is idempotent.)
- **`tree-builder.js`** — took the sidecar-rewrite side: dropped `findConnectionProfile` import + `withConnectionProfile`, kept `consolidateSiblingNodes` and the gutted `withSidecarOrCurrentApi`.
- **`commands.js`** — union of imports (upstream's `canReadBook`/`canWriteBook` + fork's `consolidateSiblingNodes`).

## Testing

The test suite is **red on both sides independently of this PR** — `upstream/main` currently has 169 failing tests, and the fork base has 109. This PR was verified to introduce **zero new failures**: the set of failing tests is byte-for-byte identical between this branch and the fork base (compared at the individual test-name level), and the two feature-specific test files pass fully:

```
tests/sidecar-snapshots.test.js      ✓
tests/tree-store-selection.test.js   ✓   (12/12 passing)
```

Happy to split this into stacked per-feature PRs if preferred, though note the eight shared files mean any split requires intra-file partitioning rather than clean file boundaries.

### Why one PR
The five features form one connected component through shared files — e.g. `tree-store.js` is touched by three of them, `sidecar-writer.js` by three, `ui-controller.js` by three. There is no clean file-level cut that separates them, so a single reviewable diff is the honest representation.
