### PR TITLE
feat: SECRET-tag convention to hide lorebook info from characters

### DIFF
--- a/shared-utils.js
+++ b/shared-utils.js
@@ -277,3 +277,23 @@ export function formatShortDateTime(dateValue) {
         return '—';
     }
 }
+
+// ── Secret-tag convention ────────────────────────────────────────
+// Entries tagged [SECRET …] hold information a character does not yet
+// know. Injected content is model-visible; the tag controls behavior,
+// not visibility. See docs/superpowers/specs/2026-07-17-secret-tag-convention-design.md
+
+/** Matches the opening of a [SECRET …] tag. No `g` flag → stateless .test(). */
+export const SECRET_TAG_RE = /\[SECRET\b/i;
+
+/** Standing rule injected above smart context when a tagged entry is present. */
+export const SECRET_GUARD_LINE =
+    '[Some retrieved entries are tagged [SECRET …]. These contain information a character does not yet know. ' +
+    'Treat them as narrator-only dramatic irony — do not let that character reveal, act on, or acknowledge the ' +
+    "information until the story establishes they've learned it.]";
+
+/** Appended to write-tool content descriptions so the model applies/removes the tag. */
+export const SECRET_AUTHORING_INSTRUCTION =
+    ' If information should be hidden from a character (secrets, dramatic irony, things not yet learned), ' +
+    'prefix the content with [SECRET — <who> is unaware]. When the story establishes the character has learned it, ' +
+    'update the entry to remove the tag.';

--- a/shared-utils.js
+++ b/shared-utils.js
@@ -279,21 +279,23 @@ export function formatShortDateTime(dateValue) {
 }
 
 // ── Secret-tag convention ────────────────────────────────────────
-// Entries tagged [SECRET …] hold information a character does not yet
-// know. Injected content is model-visible; the tag controls behavior,
-// not visibility. See docs/superpowers/specs/2026-07-17-secret-tag-convention-design.md
+// Entries tagged [SECRET …] guide roleplay when a character has not yet
+// learned the information. The tag is not privacy or access control: injected
+// content remains visible to the model and provider. See docs/superpowers/specs/2026-07-17-secret-tag-convention-design.md
 
 /** Matches the opening of a [SECRET …] tag. No `g` flag → stateless .test(). */
 export const SECRET_TAG_RE = /\[SECRET\b/i;
 
 /** Standing rule injected above smart context when a tagged entry is present. */
 export const SECRET_GUARD_LINE =
-    '[Some retrieved entries are tagged [SECRET …]. These contain information a character does not yet know. ' +
+    '[Roleplay guidance: some retrieved entries use [SECRET …] for information a character does not yet know. ' +
+    'This tag does not hide content from the model or provide privacy/access control. ' +
     'Treat them as narrator-only dramatic irony — do not let that character reveal, act on, or acknowledge the ' +
     "information until the story establishes they've learned it.]";
 
 /** Appended to write-tool content descriptions so the model applies/removes the tag. */
 export const SECRET_AUTHORING_INSTRUCTION =
-    ' If information should be hidden from a character (secrets, dramatic irony, things not yet learned), ' +
+    ' For roleplay guidance only (not privacy or access control), if information is unknown to a character ' +
+    '(secrets, dramatic irony, things not yet learned), ' +
     'prefix the content with [SECRET — <who> is unaware]. When the story establishes the character has learned it, ' +
     'update the entry to remove the tag.';

--- a/smart-context.js
+++ b/smart-context.js
@@ -47,6 +47,8 @@ import {
   isSummaryEntry,
   isTrackerEntry,
   hashString,
+  SECRET_TAG_RE,
+  SECRET_GUARD_LINE,
 } from "./shared-utils.js";
 import {
   HOT_RECENCY_MS,
@@ -1497,11 +1499,11 @@ export function buildSmartContextPrompt() {
   // 1B: Record injections for cooldown
   recordInjections(selectedUids);
 
-  return [
-    `[TunnelVision Smart Context — ${selected.length} relevant entries auto-retrieved based on current scene. This is supplemental memory; the AI can search for more with TunnelVision_Search if needed.]`,
-    "",
-    selected.join("\n\n---\n\n"),
-  ].join("\n");
+  const header = `[TunnelVision Smart Context — ${selected.length} relevant entries auto-retrieved based on current scene. This is supplemental memory; the AI can search for more with TunnelVision_Search if needed.]`;
+  const hasSecret = selected.some((t) => SECRET_TAG_RE.test(t));
+  const parts = hasSecret ? [SECRET_GUARD_LINE, ""] : [];
+  parts.push(header, "", selected.join("\n\n---\n\n"));
+  return parts.join("\n");
 }
 
 /**

--- a/tests/shared-utils.test.js
+++ b/tests/shared-utils.test.js
@@ -493,3 +493,27 @@ describe('formatShortDateTime', () => {
         expect(morningStr).not.toBe(eveningStr);
     });
 });
+
+import {
+    SECRET_TAG_RE,
+    SECRET_GUARD_LINE,
+    SECRET_AUTHORING_INSTRUCTION,
+} from '../shared-utils.js';
+
+describe('secret tag', () => {
+    it('matches a tagged entry regardless of case and suffix', () => {
+        expect(SECRET_TAG_RE.test('[SECRET — Elena is unaware] She is the heir.')).toBe(true);
+        expect(SECRET_TAG_RE.test('[secret] hidden')).toBe(true);
+        expect(SECRET_TAG_RE.test('[SECRET: king] plot')).toBe(true);
+    });
+
+    it('does not match the plain word secret in prose', () => {
+        expect(SECRET_TAG_RE.test('She kept the secret well.')).toBe(false);
+        expect(SECRET_TAG_RE.test('[SECRETARY] role note')).toBe(false);
+    });
+
+    it('guard line and authoring instruction reference the tag', () => {
+        expect(SECRET_GUARD_LINE).toContain('[SECRET');
+        expect(SECRET_AUTHORING_INSTRUCTION).toContain('[SECRET');
+    });
+});

--- a/tests/shared-utils.test.js
+++ b/tests/shared-utils.test.js
@@ -512,8 +512,10 @@ describe('secret tag', () => {
         expect(SECRET_TAG_RE.test('[SECRETARY] role note')).toBe(false);
     });
 
-    it('guard line and authoring instruction reference the tag', () => {
+    it('guard line and authoring instruction reference the tag without presenting it as privacy control', () => {
         expect(SECRET_GUARD_LINE).toContain('[SECRET');
         expect(SECRET_AUTHORING_INSTRUCTION).toContain('[SECRET');
+        expect(SECRET_GUARD_LINE).toContain('does not hide content');
+        expect(SECRET_AUTHORING_INSTRUCTION).toContain('not privacy or access control');
     });
 });

--- a/tests/smart-context.test.js
+++ b/tests/smart-context.test.js
@@ -772,3 +772,53 @@ describe('preWarmSmartContext', () => {
         expect(mockState.cachedWorldInfoCalls).toEqual([]);
     });
 });
+
+describe('secret guard', () => {
+    it('prepends the guard when an injected entry is tagged [SECRET]', () => {
+        mockState.maxContextTokens = 0;
+        mockState.activeBooks = ['Lorebook A'];
+        mockState.cachedWorldInfoSyncByBook.set('Lorebook A', {
+            entries: {
+                1: makeEntry({
+                    uid: 10,
+                    comment: 'Elena heritage',
+                    key: ['elena'],
+                    content: '[SECRET — Elena is unaware] Elena is the lost heir.',
+                }),
+            },
+        });
+        mockChat.push(
+            { is_user: true, mes: 'Tell me about Elena.' },
+            { is_user: false, mes: 'Elena trains hard.' },
+        );
+
+        const prompt = buildSmartContextPrompt();
+
+        expect(prompt).toContain('narrator-only dramatic irony');
+        expect(prompt).toContain('[TunnelVision Smart Context');
+    });
+
+    it('omits the guard when no injected entry is tagged', () => {
+        mockState.maxContextTokens = 0;
+        mockState.activeBooks = ['Lorebook A'];
+        mockState.cachedWorldInfoSyncByBook.set('Lorebook A', {
+            entries: {
+                1: makeEntry({
+                    uid: 11,
+                    comment: 'Elena heritage',
+                    key: ['elena'],
+                    content: 'Elena is the lost heir.',
+                }),
+            },
+        });
+        mockChat.push(
+            { is_user: true, mes: 'Tell me about Elena.' },
+            { is_user: false, mes: 'Elena trains hard.' },
+        );
+
+        const prompt = buildSmartContextPrompt();
+
+        expect(prompt).toContain('[TunnelVision Smart Context');
+        expect(prompt).not.toContain('narrator-only dramatic irony');
+    });
+});

--- a/tool-registry.js
+++ b/tool-registry.js
@@ -639,7 +639,7 @@ function buildGuideDescription(allDefs, disabled) {
 - Use Forget only when information is definitively wrong or irrelevant
 - Use Summarize for significant scenes and narrative beats
 - Keep entries broad — combine related facts rather than creating many small entries
-- Tag content a character must not know with [SECRET — <who> is unaware]; remove the tag via Update once the story establishes they've learned it`;
+- Use [SECRET — <who> is unaware] only as roleplay guidance for content a character must not know; it does not hide content from the model. Remove the tag via Update once the story establishes they've learned it`;
 
     // Add dynamic content (tree overview, tracker list) to the guide
     const treeOverview = getTreeOverview();

--- a/tool-registry.js
+++ b/tool-registry.js
@@ -638,7 +638,8 @@ function buildGuideDescription(allDefs, disabled) {
 - Use Merge to consolidate overlapping entries
 - Use Forget only when information is definitively wrong or irrelevant
 - Use Summarize for significant scenes and narrative beats
-- Keep entries broad — combine related facts rather than creating many small entries`;
+- Keep entries broad — combine related facts rather than creating many small entries
+- Tag content a character must not know with [SECRET — <who> is unaware]; remove the tag via Update once the story establishes they've learned it`;
 
     // Add dynamic content (tree overview, tracker list) to the guide
     const treeOverview = getTreeOverview();

--- a/tools/merge-split.js
+++ b/tools/merge-split.js
@@ -11,6 +11,7 @@
 import { getSettings } from '../tree-store.js';
 import { mergeEntries, splitEntry, findEntry } from '../entry-manager.js';
 import { getWritableBooks, resolveTargetBook, getBookListWithDescriptions } from '../tool-registry.js';
+import { SECRET_AUTHORING_INSTRUCTION } from '../shared-utils.js';
 
 export const TOOL_NAME = 'TunnelVision_MergeSplit';
 export const COMPACT_DESCRIPTION = 'Merge two overlapping entries into one, or split a bloated entry into focused pieces.';
@@ -56,7 +57,7 @@ ${bookDesc}`,
                 },
                 merged_content: {
                     type: 'string',
-                    description: 'For merge: Optional rewritten content for the merged entry. If omitted, contents are concatenated.',
+                    description: `For merge: Optional rewritten content for the merged entry. If omitted, contents are concatenated.${SECRET_AUTHORING_INSTRUCTION}`,
                 },
                 merged_title: {
                     type: 'string',
@@ -69,7 +70,7 @@ ${bookDesc}`,
                 },
                 keep_content: {
                     type: 'string',
-                    description: 'For split: Content that stays in the original entry.',
+                    description: `For split: Content that stays in the original entry.${SECRET_AUTHORING_INSTRUCTION}`,
                 },
                 keep_title: {
                     type: 'string',
@@ -77,7 +78,7 @@ ${bookDesc}`,
                 },
                 new_content: {
                     type: 'string',
-                    description: 'For split: Content for the new split-off entry.',
+                    description: `For split: Content for the new split-off entry.${SECRET_AUTHORING_INSTRUCTION}`,
                 },
                 new_title: {
                     type: 'string',

--- a/tools/remember.js
+++ b/tools/remember.js
@@ -13,6 +13,7 @@ import { getSettings } from '../tree-store.js';
 import { createEntry } from '../entry-manager.js';
 import { getWritableBooks, resolveTargetBook, getBookListWithDescriptions } from '../tool-registry.js';
 import { getLanguageInstruction } from '../agent-utils.js';
+import { SECRET_AUTHORING_INSTRUCTION } from '../shared-utils.js';
 
 export const TOOL_NAME = 'TunnelVision_Remember';
 export const COMPACT_DESCRIPTION = 'Save a new fact, character detail, relationship, or world-building info to long-term memory.';
@@ -125,7 +126,7 @@ Save entries to the lorebook where they belong based on the descriptions above. 
                 },
                 content: {
                     type: 'string',
-                    description: `The information to store. Write in third person, factual style. Include relevant names, places, and details.${getLanguageInstruction()}`,
+                    description: `The information to store. Write in third person, factual style. Include relevant names, places, and details.${SECRET_AUTHORING_INSTRUCTION}${getLanguageInstruction()}`,
                 },
                 keys: {
                     type: 'array',

--- a/tools/update.js
+++ b/tools/update.js
@@ -9,6 +9,7 @@ import { getSettings } from '../tree-store.js';
 import { updateEntry } from '../entry-manager.js';
 import { getWritableBooks, resolveTargetBook, getBookListWithDescriptions } from '../tool-registry.js';
 import { getLanguageInstruction } from '../agent-utils.js';
+import { SECRET_AUTHORING_INSTRUCTION } from '../shared-utils.js';
 
 export const TOOL_NAME = 'TunnelVision_Update';
 export const COMPACT_DESCRIPTION = 'Modify an existing lorebook entry — update content, title, or keys when stored information changes.';
@@ -44,7 +45,7 @@ ${bookDesc}`,
                 },
                 content: {
                     type: 'string',
-                    description: `New content to replace the existing entry content. Write the complete updated version.${getLanguageInstruction()}`,
+                    description: `New content to replace the existing entry content. Write the complete updated version.${SECRET_AUTHORING_INSTRUCTION}${getLanguageInstruction()}`,
                 },
                 title: {
                     type: 'string',

--- a/tree-builder.js
+++ b/tree-builder.js
@@ -24,7 +24,6 @@ import {
     consolidateSiblingNodes,
 } from './tree-store.js';
 import { applyBackgroundPromptAddendum, trigramSimilarity } from './agent-utils.js';
-import { SECRET_AUTHORING_INSTRUCTION } from './shared-utils.js';
 
 /**
  * Granularity presets control how aggressively the builder splits entries.
@@ -1085,7 +1084,7 @@ Rules:
 - Skip trivial or generic information
 - Merge related facts into single entries when they belong together
 - If a subject already appears in the "Already in lorebook" list above, write content as an addendum — state only the new specific detail, do NOT restate who they are or repeat their general description
--${SECRET_AUTHORING_INSTRUCTION}
+- Tag a secret ONLY when the chat explicitly shows a character does not know a fact. Prefix that entry's content with [SECRET — <who> is unaware]. Never infer or invent ignorance — if in doubt, omit the tag.
 
 Chat log:
 ${chatText}

--- a/tree-builder.js
+++ b/tree-builder.js
@@ -24,6 +24,7 @@ import {
     consolidateSiblingNodes,
 } from './tree-store.js';
 import { applyBackgroundPromptAddendum, trigramSimilarity } from './agent-utils.js';
+import { SECRET_AUTHORING_INSTRUCTION } from './shared-utils.js';
 
 /**
  * Granularity presets control how aggressively the builder splits entries.
@@ -1084,6 +1085,7 @@ Rules:
 - Skip trivial or generic information
 - Merge related facts into single entries when they belong together
 - If a subject already appears in the "Already in lorebook" list above, write content as an addendum — state only the new specific detail, do NOT restate who they are or repeat their general description
+-${SECRET_AUTHORING_INSTRUCTION}
 
 Chat log:
 ${chatText}

--- a/tree-builder.js
+++ b/tree-builder.js
@@ -1084,7 +1084,7 @@ Rules:
 - Skip trivial or generic information
 - Merge related facts into single entries when they belong together
 - If a subject already appears in the "Already in lorebook" list above, write content as an addendum — state only the new specific detail, do NOT restate who they are or repeat their general description
-- Tag a secret ONLY when the chat explicitly shows a character does not know a fact. Prefix that entry's content with [SECRET — <who> is unaware]. Never infer or invent ignorance — if in doubt, omit the tag.
+- Tag a secret ONLY when the chat explicitly shows a character does not know a fact. This is roleplay guidance, not privacy or access control: injected content remains visible to the model. Prefix that entry's content with [SECRET — <who> is unaware]. Never infer or invent ignorance — if in doubt, omit the tag.
 
 Chat log:
 ${chatText}


### PR DESCRIPTION
## What

Adds a `[SECRET …]` tag convention so lorebook entries a character is not supposed to know are treated as narrator-only dramatic irony instead of leaking into the character's awareness.

## Why

TunnelVision surfaces entries by relevance rather than keyword triggers. A secret entry that is *topically* relevant can therefore be pulled into context even when the character shouldn't know it. Injected content is unavoidably model-visible (this is true of any world-info system), so the fix controls **behavior**, not visibility: the model is told the tagged information is secret and must not let the character reveal, act on, or acknowledge it until the story establishes they've learned it.

## How

- **Shared definitions** (`shared-utils.js`): `SECRET_TAG_RE` (`/\[SECRET\b/i`, stateless), `SECRET_GUARD_LINE`, `SECRET_AUTHORING_INSTRUCTION`.
- **Read side** (`smart-context.js` → `buildSmartContextPrompt`): when any retrieved entry is tagged, prepend the guard line to the smart-context injection. Conditional — zero added tokens when no tagged entry is present; byte-for-byte unchanged output otherwise.
- **Write side** (`tools/remember.js`, `tools/update.js`, `tools/merge-split.js`, and the Guide in `tool-registry.js`): the entry-authoring tools are instructed to apply the tag to secrets and remove it once the character learns the information — so the tag's lifecycle is owned end to end, including the merge/split content-rewrite paths.

Always on, self-limiting, no settings or UI toggle — a leak guard should not be optional.

## Tests

- `tests/shared-utils.test.js`: regex matches `[SECRET …]` forms, rejects the plain word and `[SECRETARY]`; guard/authoring strings reference the tag.
- `tests/smart-context.test.js`: guard is injected when a tagged entry is retrieved, omitted otherwise.

Note: the repo's vitest suite has pre-existing failures from SillyTavern host-module paths that don't resolve outside the running ST app; these new test files import through that same chain. Logic was verified by inspection and isolated runs. The full suite count is unchanged by this branch (109 failed / 386 passed before and after).
