### PR TITLE
Fix sidecar latching off after transient failures, and swipe context contamination

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -571,9 +571,14 @@ export const CIRCUIT_BREAKER_COOLDOWN_MS = 5 * 60 * 1000;
  * Default timeout (ms) for a single sidecar LLM generation request.
  * Prevents indefinite hangs when the endpoint is unresponsive.
  *
+ * Sized for slow providers: retrieval and writer prompts are large, and a
+ * backend running at a few tokens/sec can legitimately take over a minute.
+ * Too tight a value shows up as AbortError, which trips the circuit breaker
+ * and silently disables the sidecar.
+ *
  * @see llm-sidecar.js — sidecarGenerate
  */
-export const SIDECAR_DEFAULT_TIMEOUT_MS = 30_000;
+export const SIDECAR_DEFAULT_TIMEOUT_MS = 90_000;
 
 /**
  * Timeout (ms) for sidecar connectivity tests. Shorter than the

--- a/index.js
+++ b/index.js
@@ -999,7 +999,7 @@ async function onGenerationStarted(type, opts, dryRun) {
     // Sidecar auto-retrieval: pre-fetch relevant entries before generation (first pass only)
     if (settings.sidecarAutoRetrieval && settings.globalEnabled !== false) {
         try {
-            await runSidecarRetrieval();
+            await runSidecarRetrieval(type);
         } catch (err) {
             console.error('[TunnelVision] Sidecar auto-retrieval error:', err);
         }

--- a/llm-sidecar.js
+++ b/llm-sidecar.js
@@ -10,7 +10,7 @@
  */
 
 import { getSettings } from './tree-store.js';
-import { SIDECAR_DEFAULT_TIMEOUT_MS } from './constants.js';
+import { SIDECAR_DEFAULT_TIMEOUT_MS, CIRCUIT_BREAKER_THRESHOLD, CIRCUIT_BREAKER_COOLDOWN_MS } from './constants.js';
 
 const MODULE_NAME = 'TunnelVision';
 const THINK_BLOCK_RE = /<think[\s\S]*?<\/think>/gi;
@@ -18,23 +18,49 @@ const THINK_BLOCK_RE = /<think[\s\S]*?<\/think>/gi;
 // ─── Circuit Breaker ────────────────────────────────────────────────
 // Opens after BREAKER_THRESHOLD consecutive sidecarGenerate failures; a single
 // success resets it. Prevents hammering a misconfigured endpoint.
-const BREAKER_THRESHOLD = 3;
+//
+// The breaker re-closes on its own after BREAKER_COOLDOWN_MS. A slow or flaky
+// provider trips it in three turns, and without a cooldown the sidecar would
+// stay dead for the rest of the page session — including after the provider
+// recovered — with the user seeing only that it silently stopped working.
+const BREAKER_THRESHOLD = CIRCUIT_BREAKER_THRESHOLD;
+const BREAKER_COOLDOWN_MS = CIRCUIT_BREAKER_COOLDOWN_MS;
 let _failureCount = 0;
 let _breakerOpen = false;
+let _breakerOpenedAt = 0;
 
 export function resetCircuitBreaker() {
     _failureCount = 0;
     _breakerOpen = false;
+    _breakerOpenedAt = 0;
 }
 
 function _recordFailure() {
     _failureCount += 1;
-    if (_failureCount >= BREAKER_THRESHOLD) _breakerOpen = true;
+    if (_failureCount >= BREAKER_THRESHOLD) {
+        _breakerOpen = true;
+        _breakerOpenedAt = Date.now();
+        console.warn(`[TunnelVision] Sidecar circuit breaker OPEN after ${_failureCount} consecutive failures — retrying in ${Math.round(BREAKER_COOLDOWN_MS / 60_000)} min. Check the Sidecar LLM endpoint if this repeats.`);
+    }
 }
 
 function _recordSuccess() {
-    _failureCount = 0;
-    _breakerOpen = false;
+    resetCircuitBreaker();
+}
+
+/**
+ * True when the breaker has tripped and the cooldown has not yet elapsed.
+ * Distinguishes "temporarily broken" from "unconfigured". Expiring the cooldown
+ * here means the next call goes through and either succeeds (closing the
+ * breaker) or fails (re-opening it) — a half-open probe without a scheduler.
+ */
+export function isCircuitOpen() {
+    if (_breakerOpen && Date.now() - _breakerOpenedAt >= BREAKER_COOLDOWN_MS) {
+        console.debug('[TunnelVision] Sidecar circuit breaker cooldown elapsed — retrying sidecar on next call.');
+        _breakerOpen = false;
+        _failureCount = BREAKER_THRESHOLD - 1; // one more failure re-opens it
+    }
+    return _breakerOpen;
 }
 
 // ─── Config Resolution ──────────────────────────────────────────────
@@ -62,7 +88,7 @@ export function getSidecarConfig() {
 
 /** True when sidecar is fully configured and the circuit breaker is closed. */
 export function isSidecarConfigured() {
-    return !_breakerOpen && getSidecarConfig() !== null;
+    return !isCircuitOpen() && getSidecarConfig() !== null;
 }
 
 /** Display label for the activity feed. */
@@ -105,6 +131,12 @@ async function _fetchJson(url, options, label) {
     let response;
     try {
         response = await fetch(url, { ...options, signal: controller.signal });
+    } catch (error) {
+        // A bare AbortError reads as "signal is aborted without reason" — name the timeout.
+        if (error?.name === 'AbortError') {
+            throw new Error(`${label} timed out after ${SIDECAR_DEFAULT_TIMEOUT_MS / 1000}s — the sidecar endpoint did not respond in time.`);
+        }
+        throw error;
     } finally {
         clearTimeout(timer);
     }
@@ -138,7 +170,7 @@ function _modelsBase(endpoint) {
  * @returns {Promise<string>}
  */
 export async function sidecarGenerate({ prompt, systemPrompt }) {
-    if (_breakerOpen) {
+    if (isCircuitOpen()) {
         throw new Error('Sidecar circuit breaker open — too many consecutive failures. Check the Sidecar LLM configuration.');
     }
     const config = getSidecarConfig();
@@ -265,6 +297,9 @@ async function _embedGoogle({ endpoint, apiKey, model, texts }) {
 export async function testSidecarConnectivity() {
     const config = getSidecarConfig();
     if (!config) return { ok: false, message: 'No sidecar configuration to test.', latencyMs: 0 };
+    // An explicit user-run test is the reset point for the breaker — otherwise a tripped
+    // breaker short-circuits sidecarGenerate and the test can never report success.
+    resetCircuitBreaker();
     const start = Date.now();
     try {
         const text = await sidecarGenerate({ prompt: 'Reply with the single word: OK' });

--- a/sidecar-retrieval.js
+++ b/sidecar-retrieval.js
@@ -112,17 +112,25 @@ function formatNodeForSidecar(node, depth, isRoot = false) {
 /**
  * Extract recent chat messages for sidecar context.
  * @param {number} maxMessages
+ * @param {boolean} [dropLast] Exclude the tail message (swipes — see below).
  * @returns {string}
  */
-function extractRecentChat(maxMessages = 10) {
+function extractRecentChat(maxMessages = 10, dropLast = false) {
     const context = getContext();
     const chat = context.chat;
     if (!chat || chat.length === 0) return '';
 
-    const lines = [];
-    const start = Math.max(0, chat.length - maxMessages);
+    // On a swipe the rejected response is still sitting in chat[] — ST only drops
+    // it from its own prompt (`if (type === 'swipe') coreChat.pop()`) long after
+    // GENERATION_STARTED fires, so we have to drop it ourselves or the sidecar
+    // retrieves lore based on the response the user just rejected.
+    const end = dropLast ? chat.length - 1 : chat.length;
+    if (end <= 0) return '';
 
-    for (let i = start; i < chat.length; i++) {
+    const lines = [];
+    const start = Math.max(0, end - maxMessages);
+
+    for (let i = start; i < end; i++) {
         const msg = chat[i];
         if (msg.is_system) continue;
         const role = msg.is_user ? 'User' : 'Character';
@@ -438,9 +446,10 @@ async function resolveConditionalContent(evaluations, conditionalEntries) {
  * Run sidecar auto-retrieval before a generation.
  * Called from onGenerationStarted in index.js.
  *
+ * @param {string} [type] ST generation type — 'swipe' excludes the rejected tail message.
  * @returns {Promise<void>}
  */
-export async function runSidecarRetrieval() {
+export async function runSidecarRetrieval(type = null) {
     const settings = getSettings();
 
     // Guard: must be enabled and sidecar must be configured
@@ -466,7 +475,7 @@ export async function runSidecarRetrieval() {
 
     // Extract recent chat
     const contextMessages = settings.sidecarContextMessages ?? 10;
-    const recentChat = extractRecentChat(contextMessages);
+    const recentChat = extractRecentChat(contextMessages, type === 'swipe');
     if (!recentChat.trim()) {
         console.debug('[TunnelVision] Sidecar auto-retrieval: no recent chat context');
         return;

--- a/sidecar-retrieval.js
+++ b/sidecar-retrieval.js
@@ -25,7 +25,7 @@ import {
 } from './tree-store.js';
 import { getReadableBooks } from './tool-registry.js';
 import { hasEvaluableConditions, separateConditions, mapSelectiveLogic, describeSelectiveLogic, CONDITION_DESCRIPTIONS, CONDITION_LABELS, rollKeywordProbability, formatCondition } from './conditions.js';
-import { isSidecarConfigured, sidecarGenerate, getSidecarModelLabel } from './llm-sidecar.js';
+import { isSidecarConfigured, isCircuitOpen, sidecarGenerate, getSidecarModelLabel } from './llm-sidecar.js';
 import { logSidecarRetrieval, logConditionalEvaluations, setSidecarActive } from './activity-feed.js';
 import { getKeywordTriggeredUids } from './index.js';
 import { applyBackgroundPromptAddendum, buildLanguageDirective } from './agent-utils.js';
@@ -445,6 +445,10 @@ export async function runSidecarRetrieval() {
 
     // Guard: must be enabled and sidecar must be configured
     if (!settings.sidecarAutoRetrieval) return;
+    if (isCircuitOpen()) {
+        console.debug('[TunnelVision] Sidecar auto-retrieval: circuit breaker open — skipping');
+        return;
+    }
     if (!isSidecarConfigured()) {
         console.debug('[TunnelVision] Sidecar auto-retrieval enabled but no sidecar configured — skipping');
         return;

--- a/sidecar-writer.js
+++ b/sidecar-writer.js
@@ -25,7 +25,7 @@ import {
     getSettings,
 } from './tree-store.js';
 import { getReadableBooks, getWritableBooks, getBookListWithDescriptions, checkToolConfirmation, REMEMBER_NAME, UPDATE_NAME, FORGET_NAME, SUMMARIZE_NAME, REORGANIZE_NAME, MERGESPLIT_NAME } from './tool-registry.js';
-import { isSidecarConfigured, sidecarGenerate, getSidecarModelLabel } from './llm-sidecar.js';
+import { isSidecarConfigured, isCircuitOpen, sidecarGenerate, getSidecarModelLabel } from './llm-sidecar.js';
 import { getDefinition as getRememberDef } from './tools/remember.js';
 import { getDefinition as getUpdateDef } from './tools/update.js';
 import { getDefinition as getSummarizeDef } from './tools/summarize.js';
@@ -1050,6 +1050,10 @@ export async function runSidecarWriter(messageId = null) {
 
     // Guard: must be enabled and sidecar must be configured
     if (!settings.sidecarPostGenWriter) return;
+    if (isCircuitOpen()) {
+        console.debug('[TunnelVision] Sidecar post-gen writer: circuit breaker open — skipping');
+        return;
+    }
     if (!isSidecarConfigured()) {
         console.debug('[TunnelVision] Sidecar post-gen writer enabled but no sidecar configured — skipping');
         return;

--- a/tests/llm-sidecar.test.js
+++ b/tests/llm-sidecar.test.js
@@ -13,6 +13,7 @@ import {
     isSidecarConfigured,
     getSidecarConfig,
     resetCircuitBreaker,
+    isCircuitOpen,
     sidecarGenerate,
     getEmbeddingConfig,
     isEmbeddingSupported,
@@ -181,6 +182,28 @@ describe('resetCircuitBreaker', () => {
         resetCircuitBreaker();
         expect(isSidecarConfigured()).toBe(true);
 
+        vi.unstubAllGlobals();
+    });
+
+    it('re-closes on its own once the cooldown elapses', async () => {
+        mockSidecarProfile = { ...validProfile };
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+        for (let i = 0; i < 3; i++) {
+            try { await sidecarGenerate({ prompt: 'test' }); } catch { /* expected */ }
+        }
+        expect(isCircuitOpen()).toBe(true);
+
+        // Jump past the 5-minute cooldown — the breaker should allow a probe.
+        vi.useFakeTimers();
+        vi.setSystemTime(Date.now() + 5 * 60 * 1000 + 1);
+        expect(isCircuitOpen()).toBe(false);
+
+        // One further failure re-opens it immediately (no free second run).
+        try { await sidecarGenerate({ prompt: 'test' }); } catch { /* expected */ }
+        expect(isCircuitOpen()).toBe(true);
+
+        vi.useRealTimers();
         vi.unstubAllGlobals();
     });
 });

--- a/tests/sidecar-retrieval-swipe.test.js
+++ b/tests/sidecar-retrieval-swipe.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Host context + heavy local deps mocked so we can exercise the retrieval
+// prompt in isolation and assert what the sidecar actually gets told.
+vi.mock('../../../st-context.js', () => ({ getContext: vi.fn() }));
+vi.mock('../../../../script.js', () => ({
+    setExtensionPrompt: vi.fn(),
+    extension_prompt_types: { IN_PROMPT: 0, IN_CHAT: 1, BEFORE_PROMPT: 2 },
+    extension_prompt_roles: { SYSTEM: 0, USER: 1, ASSISTANT: 2 },
+}));
+vi.mock('../../../world-info.js', () => ({ loadWorldInfo: vi.fn(async () => ({ entries: {} })) }));
+vi.mock('../tree-store.js', () => ({
+    getTree: vi.fn(() => ({ root: { id: 'root', label: 'Root', children: [] } })),
+    findNodeById: vi.fn(() => null),
+    getAllEntryUids: vi.fn(() => []),
+    getSettings: vi.fn(() => ({ sidecarAutoRetrieval: true, sidecarContextMessages: 10, conditionalTriggersEnabled: false })),
+    isNativeInjectionBook: vi.fn(() => false),
+}));
+vi.mock('../tool-registry.js', () => ({ getReadableBooks: vi.fn(() => ['Book']) }));
+vi.mock('../conditions.js', () => ({
+    hasEvaluableConditions: vi.fn(() => false),
+    separateConditions: vi.fn(() => ({ conditions: [], keywords: [] })),
+    mapSelectiveLogic: vi.fn(() => 'AND_ANY'),
+    describeSelectiveLogic: vi.fn(() => ''),
+    rollKeywordProbability: vi.fn(() => true),
+    formatCondition: vi.fn(() => ''),
+    CONDITION_DESCRIPTIONS: {},
+    CONDITION_LABELS: {},
+}));
+vi.mock('../llm-sidecar.js', () => ({
+    isSidecarConfigured: vi.fn(() => true),
+    isCircuitOpen: vi.fn(() => false),
+    sidecarGenerate: vi.fn(async () => 'NODES: none'),
+    getSidecarModelLabel: vi.fn(() => 'test-model'),
+}));
+vi.mock('../activity-feed.js', () => ({
+    logSidecarRetrieval: vi.fn(),
+    logConditionalEvaluations: vi.fn(),
+    setSidecarActive: vi.fn(),
+}));
+vi.mock('../index.js', () => ({ getKeywordTriggeredUids: vi.fn(() => []) }));
+vi.mock('../agent-utils.js', () => ({
+    applyBackgroundPromptAddendum: vi.fn(s => s),
+    buildLanguageDirective: vi.fn(() => ''),
+}));
+
+const { getContext } = await import('../../../st-context.js');
+const { sidecarGenerate } = await import('../llm-sidecar.js');
+const { runSidecarRetrieval } = await import('../sidecar-retrieval.js');
+
+/** Chat where the tail is an assistant reply the user is about to swipe away. */
+const CHAT = [
+    { is_user: true, is_system: false, mes: 'user question here' },
+    { is_user: false, is_system: false, mes: 'REJECTED SWIPE TEXT' },
+];
+
+/** @returns {string} the prompt handed to the sidecar LLM */
+function promptSentToSidecar() {
+    return sidecarGenerate.mock.calls.at(-1)[0].prompt;
+}
+
+describe('sidecar retrieval — swipe tail handling', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getContext.mockReturnValue({ chat: CHAT });
+    });
+
+    it('excludes the rejected response from the prompt on a swipe', async () => {
+        await runSidecarRetrieval('swipe');
+
+        const prompt = promptSentToSidecar();
+        expect(prompt).not.toContain('REJECTED SWIPE TEXT');
+        expect(prompt).toContain('user question here');
+    });
+
+    it('includes the tail message on a normal generation', async () => {
+        await runSidecarRetrieval('normal');
+
+        expect(promptSentToSidecar()).toContain('REJECTED SWIPE TEXT');
+    });
+
+    it('does not run at all when a swipe leaves no usable context', async () => {
+        getContext.mockReturnValue({ chat: [{ is_user: false, is_system: false, mes: 'only message' }] });
+
+        await runSidecarRetrieval('swipe');
+
+        expect(sidecarGenerate).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Two independent sidecar fixes, each with tests.

## 1. The sidecar stops firing for the rest of the session after a slow provider

A slow backend makes sidecar requests abort at the 30s timeout. Three aborts trip the circuit breaker, and the breaker then latches for the remainder of the page session — the sidecar silently stops firing on every later message, long after the provider recovered. The only visible symptom is that it quietly stopped working.

- Implements the cooldown `constants.js` already documented. Both `CIRCUIT_BREAKER_THRESHOLD` and `CIRCUIT_BREAKER_COOLDOWN_MS` existed, the latter annotated `@see llm-sidecar.js — isCircuitOpen`, but no cooldown was ever written and `llm-sidecar.js` hardcoded its own threshold. `isCircuitOpen()` now expires the breaker after the cooldown and lets the next call act as a half-open probe: it succeeds and closes the breaker, or fails and re-opens it. No scheduler needed.
- Exports `isCircuitOpen()` and checks it in retrieval and the post-gen writer, so an open breaker short-circuits before prompt assembly rather than after a failed request.
- Resets the breaker at the start of `testSidecarConnectivity()`. The test runs through `sidecarGenerate`, which short-circuits when the breaker is open, so a tripped breaker could never be cleared from the UI.
- Raises `SIDECAR_DEFAULT_TIMEOUT_MS` from 30s to 90s. Retrieval and writer prompts are large, and a backend at a few tokens/sec exceeds 30s routinely.
- Surfaces `AbortError` as a named timeout; `signal is aborted without reason` gave no indication a timeout was the cause.

## 2. Sidecar retrieval reads the rejected response on swipes

On a swipe, ST leaves the previous response in `chat[]` and only drops it from its own prompt at `script.js` `if (type === 'swipe') coreChat.pop()` — roughly 200 lines after `GENERATION_STARTED` fires. Sidecar retrieval runs on that event and walked the whole chat array, so it selected lore based on the response the user had just rejected: swipe 4 retrieving context chosen for swipe 3. Silent — it degraded relevance and never errored.

`extractRecentChat()` gains a `dropLast` flag and windows over the trimmed end; `runSidecarRetrieval()` takes the generation type and sets it for swipes. This mirrors what ST already does for its own prompt.

The post-gen writer is unaffected: `index.js` already excludes `swipe` from its `skipTypes`, and `sidecar-writer.js`'s own `extractRecentChat` drops a trailing character message unconditionally.

## Testing

- New `tests/sidecar-retrieval-swipe.test.js` (3 tests) asserts the rejected response is absent from the prompt on a swipe, present on a normal generation, and that a swipe leaving no usable context skips cleanly rather than sending an empty prompt.
- `tests/llm-sidecar.test.js` extended for the cooldown and half-open probe.
- Full suite on this branch: 503 tests, 394 passing, 109 failing — the same 109 that fail on a clean `upstream/main` checkout, unchanged by this PR.
