### PR TITLE
feat: expose Rolling World State, Smart Context, and Memory Lifecycle settings (stacked on #35)

### DIFF
--- a/activity-feed.js
+++ b/activity-feed.js
@@ -10,6 +10,7 @@ import { ALL_TOOL_NAMES, getActiveTunnelVisionBooks } from './tool-registry.js';
 import { getSettings, isLorebookEnabled, getTree } from './tree-store.js';
 import { openTreeEditorForBook } from './ui-controller.js';
 import { getSidecarModelLabel } from './llm-sidecar.js';
+import { _registerFeedCallbacks, clearFailedTasks } from './background-events.js';
 
 const MAX_FEED_ITEMS = 50;
 const MAX_RENDERED_RETRIEVED_ENTRIES = 5;
@@ -86,6 +87,17 @@ export function initActivityFeed() {
     if (feedInitialized) return;
     feedInitialized = true;
 
+    // Wire the visual side of background-events.js's callback-based event bus.
+    // Without this, addBackgroundEvent() from post-turn-processor.js, world-state.js,
+    // smart-context.js and summary-hierarchy.js is silently discarded, and failed
+    // background tasks have no UI to list or dismiss them.
+    _registerFeedCallbacks({
+        addFeedItems,
+        setTriggerActive: setBackgroundTaskActive,
+        refreshTasksUI,
+        getFeedItems,
+    });
+
     loadFeed();
     createTriggerButton();
     createPanel();
@@ -109,6 +121,7 @@ export function initActivityFeed() {
     if (event_types.CHAT_CHANGED) {
         eventSource.on(event_types.CHAT_CHANGED, () => {
             loadFeed();
+            clearFailedTasks();
             if (panelEl?.classList.contains('open')) renderAllItems();
             queueHiddenToolCallRefresh(false);
         });
@@ -703,6 +716,24 @@ function pulseTrigger() {
 export function setSidecarActive(active) {
     if (!triggerEl) return;
     triggerEl.classList.toggle('tv-float-sidecar-active', active);
+}
+
+/**
+ * Show a visual indicator on the trigger button that a background task
+ * (post-turn processing, world-state update, lifecycle maintenance, etc.)
+ * is running. Passed to background-events.js as the `setTriggerActive` callback.
+ */
+function setBackgroundTaskActive(active) {
+    if (!triggerEl) return;
+    triggerEl.classList.toggle('tv-float-bg-active', active);
+}
+
+/**
+ * Re-render the panel (active/failed task rows) if it's currently open.
+ * Passed to background-events.js as the `refreshTasksUI` callback.
+ */
+function refreshTasksUI() {
+    if (panelEl?.classList.contains('open')) renderAllItems();
 }
 
 function trimFeed() {

--- a/auto-summary.js
+++ b/auto-summary.js
@@ -11,6 +11,7 @@ import { getSettings } from './tree-store.js';
 import { getActiveTunnelVisionBooks } from './tool-registry.js';
 
 const TV_AUTOSUMMARY_KEY = 'tunnelvision_autosummary';
+const TV_AUTOSUMMARY_COUNTER_KEY = 'tunnelvision_autosummary_counter';
 
 /** Message count since last summary, keyed by chatId */
 const counters = new Map();
@@ -21,6 +22,10 @@ let _autoSummaryInitialized = false;
 export function initAutoSummary() {
     if (_autoSummaryInitialized) return;
     _autoSummaryInitialized = true;
+
+    // Restore the counter for whatever chat is already loaded (CHAT_CHANGED
+    // may not fire again for a chat that was loaded before this ran).
+    hydrateCounterFromMetadata();
 
     // Count user+AI messages
     if (event_types.MESSAGE_RECEIVED) {
@@ -57,6 +62,7 @@ function onMessageReceived() {
 
     const count = (counters.get(chatId) || 0) + 1;
     counters.set(chatId, count);
+    persistCounter(chatId, count);
 }
 
 function onGenerationForAutoSummary() {
@@ -100,11 +106,38 @@ function onGenerationForAutoSummary() {
 }
 
 function onChatChanged() {
+    hydrateCounterFromMetadata();
     clearPrompt();
 }
 
 function clearPrompt() {
     setExtensionPrompt(TV_AUTOSUMMARY_KEY, '', extension_prompt_types.IN_PROMPT, 0);
+}
+
+/**
+ * Persist the message counter to this chat's metadata so it survives a
+ * page reload or chat switch-away-and-back instead of resetting to 0.
+ */
+function persistCounter(chatId, count) {
+    try {
+        const context = getContext();
+        if (!context.chatMetadata || context.chatId !== chatId) return;
+        context.chatMetadata[TV_AUTOSUMMARY_COUNTER_KEY] = count;
+        context.saveMetadataDebounced();
+    } catch { /* no active chat */ }
+}
+
+/** Restore the in-memory counter for the active chat from its metadata. */
+function hydrateCounterFromMetadata() {
+    const chatId = getChatId();
+    if (!chatId) return;
+    try {
+        const context = getContext();
+        const stored = context.chatMetadata?.[TV_AUTOSUMMARY_COUNTER_KEY];
+        if (typeof stored === 'number' && Number.isFinite(stored)) {
+            counters.set(chatId, stored);
+        }
+    } catch { /* no active chat */ }
 }
 
 export function markAutoSummaryComplete() {
@@ -113,6 +146,7 @@ export function markAutoSummaryComplete() {
 
     counters.set(chatId, 0);
     pendingSummaries.delete(chatId);
+    persistCounter(chatId, 0);
     clearPrompt();
 }
 
@@ -130,5 +164,6 @@ export function resetAutoSummaryCount() {
 
     counters.set(chatId, 0);
     pendingSummaries.delete(chatId);
+    persistCounter(chatId, 0);
     clearPrompt();
 }

--- a/background-events.js
+++ b/background-events.js
@@ -168,6 +168,9 @@ let _nextTaskId = 0;
 /** @type {Map<number, FailedTask>} */
 const _failedTasks = new Map();
 let _nextFailedTaskId = 0;
+// Retained failure entries each pin a retryFn closure over chat/prompt state.
+// There is no bound UI to drain this map on its own, so cap it defensively.
+const MAX_FAILED_TASKS = 10;
 
 /**
  * @typedef {Object} BackgroundTask
@@ -239,6 +242,11 @@ export function registerBackgroundTask({ label, icon: taskIcon = 'fa-gear', colo
                     retryFn,
                     retrying: false,
                 });
+                // Drop the oldest entries beyond the cap (Map preserves insertion order).
+                while (_failedTasks.size > MAX_FAILED_TASKS) {
+                    const oldestKey = _failedTasks.keys().next().value;
+                    _failedTasks.delete(oldestKey);
+                }
             }
             _refreshTasksUI?.();
         },
@@ -304,6 +312,16 @@ export async function retryFailedTask(failedId) {
 /** Dismiss a failed task without retrying. */
 export function dismissFailedTask(failedId) {
     _failedTasks.delete(failedId);
+    _refreshTasksUI?.();
+}
+
+/**
+ * Clear all failed-task entries. Called on chat change so retry closures
+ * captured against the previous chat's state don't linger indefinitely.
+ */
+export function clearFailedTasks() {
+    if (_failedTasks.size === 0) return;
+    _failedTasks.clear();
     _refreshTasksUI?.();
 }
 

--- a/constants.js
+++ b/constants.js
@@ -236,6 +236,16 @@ export const EMBEDDING_MAX_TEXT_LENGTH = 500;
 export const EMBEDDING_CACHE_TTL_DAYS = 7;
 
 /**
+ * Hard cap on the number of records kept in the persistent embedding store.
+ * The TTL alone doesn't bound growth within its window — every content edit
+ * of an entry writes a new "bookName:uid:contentHash" record — so hydration
+ * also enforces this cap, evicting the oldest records beyond it.
+ *
+ * @see embedding-cache.js — hydrateFromStore eviction
+ */
+export const EMBEDDING_CACHE_MAX_RECORDS = 2000;
+
+/**
  * Embedding cosine similarity → score boost mapping.
  * Higher similarity to recent chat text earns a larger boost
  * in the smart context candidate scoring pipeline.

--- a/embedding-cache.js
+++ b/embedding-cache.js
@@ -18,6 +18,7 @@ import {
   EMBEDDING_MAX_BATCH_SIZE,
   EMBEDDING_MAX_TEXT_LENGTH,
   EMBEDDING_CACHE_TTL_DAYS,
+  EMBEDDING_CACHE_MAX_RECORDS,
   EMBEDDING_SIMILARITY_BOOSTS,
 } from "./constants.js";
 
@@ -95,6 +96,7 @@ async function hydrateFromStore() {
 
   const now = Date.now();
   const staleKeys = [];
+  const liveRecords = [];
   let loaded = 0;
 
   try {
@@ -111,6 +113,7 @@ async function hydrateFromStore() {
       const contentHash = Number(parts[parts.length - 1]);
       const memKey = parts.slice(0, parts.length - 1).join(":");
       _cache.set(memKey, { embedding: record.embedding, contentHash });
+      liveRecords.push({ key, storedAt: record.storedAt || 0 });
       loaded++;
     });
   } catch (e) {
@@ -119,6 +122,17 @@ async function hydrateFromStore() {
       e.message,
     );
     return;
+  }
+
+  // Hard cap on persisted records: the TTL alone doesn't bound growth within
+  // its window (every content edit orphans the previous vector), so evict
+  // the oldest records beyond the cap too.
+  if (liveRecords.length > EMBEDDING_CACHE_MAX_RECORDS) {
+    liveRecords.sort((a, b) => a.storedAt - b.storedAt);
+    const overflow = liveRecords.length - EMBEDDING_CACHE_MAX_RECORDS;
+    for (const { key } of liveRecords.slice(0, overflow)) {
+      staleKeys.push(key);
+    }
   }
 
   if (staleKeys.length > 0) {
@@ -152,10 +166,19 @@ function getCachedEmbedding(bookName, uid, contentHash) {
 
 function setCachedEmbedding(bookName, uid, contentHash, embedding) {
   const key = getMemCacheKey(bookName, uid);
+  const previous = _cache.get(key);
   _cache.set(key, { embedding, contentHash });
 
   const store = getStore();
   if (store) {
+    // Every content edit writes a new "bookName:uid:contentHash" record —
+    // remove the record for this entry's previous content hash first so
+    // superseded vectors don't accumulate indefinitely in IndexedDB.
+    if (previous && previous.contentHash !== contentHash) {
+      store
+        .removeItem(persistKey(bookName, uid, previous.contentHash))
+        .catch(() => {});
+    }
     store
       .setItem(persistKey(bookName, uid, contentHash), {
         embedding,

--- a/entry-manager.js
+++ b/entry-manager.js
@@ -800,10 +800,22 @@ Respond with ONLY a JSON array of fact objects (no markdown, no code fences).`;
  */
 export function buildSummaryKeys(parsed, participants = [], significance = 'moderate') {
     const keys = [];
-    if (participants?.length) keys.push(...participants);
-    if (parsed?.arc) keys.push(parsed.arc);
-    if (parsed?.when) keys.push(parsed.when);
-    if (significance) keys.push(significance);
-    // Deduplicate
-    return [...new Set(keys.filter(Boolean))];
+    if (participants?.length) {
+        keys.push(...participants.map((p) => String(p).trim().toLowerCase()));
+    }
+    // The LLM is explicitly prompted for "keys" (see summary-hierarchy.js) —
+    // merge them in instead of discarding them.
+    if (Array.isArray(parsed?.keys)) {
+        keys.push(...parsed.keys.map((k) => String(k).trim().toLowerCase()));
+    }
+    if (parsed?.arc) keys.push(String(parsed.arc).trim().toLowerCase());
+    if (parsed?.when) {
+        const when = String(parsed.when).trim().toLowerCase();
+        if (when && when !== 'unspecified') keys.push(when);
+    }
+    // Use the 'summary:<significance>' convention (matching tools/summarize.js)
+    // instead of a bare significance word.
+    if (significance) keys.push(`summary:${significance}`);
+    // Deduplicate and drop noise-length keys
+    return [...new Set(keys.filter((k) => k && k.length >= 2))];
 }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@
  *   auto-summary.js — Automatic summary injection every N messages.
  */
 
-import { eventSource, event_types, extension_prompt_types, extension_prompt_roles, setExtensionPrompt, saveSettingsDebounced, main_api } from '../../../../script.js';
+import { eventSource, event_types, extension_prompt_types, extension_prompt_roles, setExtensionPrompt, saveSettingsDebounced, saveChatConditional, main_api } from '../../../../script.js';
 import { getContext } from '../../../st-context.js';
 import { ToolManager } from '../../../tool-calling.js';
 import { renderExtensionTemplateAsync } from '../../../extensions.js';
@@ -32,7 +32,7 @@ import { initActivityFeed } from './activity-feed.js';
 import { initCommands } from './commands.js';
 import { initAutoSummary } from './auto-summary.js';
 import { initPostTurnProcessor } from './post-turn-processor.js';
-import { runSidecarRetrieval } from './sidecar-retrieval.js';
+import { runSidecarRetrieval, clearRetrievalPrompt } from './sidecar-retrieval.js';
 import { runSidecarWriter, revertMessageSnapshots, revertInvalidSnapshots, hydrateSnapshots } from './sidecar-writer.js';
 import { separateConditions, isEvaluableCondition, formatCondition, EVALUABLE_TYPES, CONDITION_LABELS, getKeywordProbability, setKeywordProbability } from './conditions.js';
 import { loadWorldInfo, saveWorldInfo, world_names, deleteWorldInfoEntry, deleteWIOriginalDataValue } from '../../../world-info.js';
@@ -168,10 +168,9 @@ async function init() {
     // Post-generation sidecar writer (remember/update after model responds)
     if (event_types.MESSAGE_RECEIVED) {
         eventSource.on(event_types.MESSAGE_RECEIVED, async (messageIndexOrId, type) => {
-            const context = getContext();
-            // Robust lookup: could be index or UID
-            const msg = context.chat[messageIndexOrId] || context.chat.find(m => m.mesId === messageIndexOrId);
-            const realMsgId = msg?.mesId;
+            // ST's ChatMessage has no `mesId` field (it only exists as a DOM
+            // attribute); MESSAGE_RECEIVED already passes the chat array index.
+            const realMsgId = messageIndexOrId;
 
             // If swiped, cleanup old memories and revert updates from the previous response
             if (type === 'swipe') {
@@ -197,21 +196,18 @@ async function init() {
         });
     }
 
-    // Refresh connection profile dropdown when profiles change
-    if (event_types.CONNECTION_PROFILE_CREATED) {
-        eventSource.on(event_types.CONNECTION_PROFILE_CREATED, () => refreshUI());
-    }
-    if (event_types.CONNECTION_PROFILE_DELETED) {
-        eventSource.on(event_types.CONNECTION_PROFILE_DELETED, () => refreshUI());
-    }
-    if (event_types.CONNECTION_PROFILE_UPDATED) {
-        eventSource.on(event_types.CONNECTION_PROFILE_UPDATED, () => refreshUI());
-    }
+    // Connection profile changes already trigger a refresh via the
+    // refreshEvents loop above (CONNECTION_PROFILE_CREATED/DELETED/UPDATED
+    // → queueStateRefresh → refreshRuntimeState → refreshUI); a second,
+    // direct registration here would double-run refreshUI() per event.
 
     console.log('[TunnelVision] Extension loaded');
 }
 
 async function onChatChanged() {
+    // A stale sidecar retrieval injection from the previous chat must not
+    // leak into the newly loaded one.
+    clearRetrievalPrompt(getSettings());
     // Auto-enable pattern-matched lorebooks FIRST so the migration below sees them
     // in getActiveTunnelVisionBooks() (autoDetect mutates the active-book set).
     autoDetectLorebooks();
@@ -309,9 +305,11 @@ async function refreshRuntimeState(reason = 'state changed') {
 // ─── WI Editor Condition Injector ────────────────────────────────
 
 let _wiCondInjecting = false;
+let _wiCondIntervalId = null;
 
 function initWIConditionInjector() {
-    setInterval(async () => {
+    if (_wiCondIntervalId !== null) return;
+    _wiCondIntervalId = setInterval(async () => {
         if (_wiCondInjecting) return;
         const settings = getSettings();
         if (!settings.conditionalTriggersEnabled) return;
@@ -790,13 +788,16 @@ function cleanOrphanedToolInvocations() {
         if (!last.is_system || !Array.isArray(last.extra?.tool_invocations)) break;
 
         // This is an orphaned tool_invocations message at the tail -- remove it
-        console.debug(`[TunnelVision] Removing orphaned tool_invocations message at index ${chat.length - 1} (tools: ${last.extra.tool_invocations.map(i => i.name).join(', ')})`);
-        chat.length = chat.length - 1;
+        const index = chat.length - 1;
+        console.debug(`[TunnelVision] Removing orphaned tool_invocations message at index ${index} (tools: ${last.extra.tool_invocations.map(i => i.name).join(', ')})`);
+        document.querySelector(`#chat .mes[mesid="${index}"]`)?.remove();
+        chat.length = index;
         removed++;
     }
 
     if (removed > 0) {
         console.log(`[TunnelVision] Removed ${removed} orphaned tool_invocations message(s) from chat tail`);
+        saveChatConditional();
     }
 }
 
@@ -889,7 +890,7 @@ function onChatCompletionSettingsReady(data) {
 
     // ── Final-pass tool stripping ────────────────────────────────────
     const recurseLimit = ToolManager.RECURSE_LIMIT ?? 5;
-    if (_toolRecursionDepth >= recurseLimit - 1) {
+    if (recurseLimit > 1 && _toolRecursionDepth >= recurseLimit - 1) {
         if (data.tools) {
             delete data.tools;
         }
@@ -1066,6 +1067,10 @@ async function onGenerationStarted(type, opts, dryRun) {
 // Debounce timer for sidecar writer in group chats — prevents firing
 // once per group member by waiting for the last MESSAGE_RECEIVED.
 let _sidecarWriterDebounceTimer = null;
+// Re-entrancy guard: prevents overlapping runSidecarWriter() invocations when
+// MESSAGE_RECEIVED fires again (e.g. a fast follow-up message) while a
+// previous writer run is still in flight.
+let _writerRunning = false;
 
 async function onMessageReceived(messageId, type) {
     console.debug(`[TunnelVision] MESSAGE_RECEIVED: messageId=${messageId} type="${type}"`);
@@ -1081,13 +1086,15 @@ async function onMessageReceived(messageId, type) {
         console.error('[TunnelVision] Failed to flush pending summary hide:', err);
     }
 
-    // Never run sidecar writer on swipes, continues, first messages, or non-generation events.
-    // Only run on normal 'normal' generation completions.
-    const skipTypes = ['swipe', 'continue', 'appendFinal', 'first_message', 'command', 'extension'];
+    // Never run sidecar writer on swipes, continues, first messages, regenerations,
+    // or non-generation events. Only run on normal 'normal' generation completions.
+    const skipTypes = ['swipe', 'continue', 'appendFinal', 'first_message', 'command', 'extension', 'regenerate'];
     if (skipTypes.includes(type)) return;
 
     const settings = getSettings();
     if (!settings.sidecarPostGenWriter || settings.globalEnabled === false) return;
+
+    if (_writerRunning) return;
 
     // In group chats, debounce: wait 800ms after the last MESSAGE_RECEIVED
     // before firing the sidecar writer, so we only run once after the
@@ -1097,19 +1104,26 @@ async function onMessageReceived(messageId, type) {
         if (_sidecarWriterDebounceTimer) clearTimeout(_sidecarWriterDebounceTimer);
         _sidecarWriterDebounceTimer = setTimeout(async () => {
             _sidecarWriterDebounceTimer = null;
+            if (_writerRunning) return;
+            _writerRunning = true;
             try {
                 await runSidecarWriter();
             } catch (err) {
                 console.error('[TunnelVision] Sidecar post-gen writer error (group):', err);
+            } finally {
+                _writerRunning = false;
             }
         }, 800);
         return;
     }
 
+    _writerRunning = true;
     try {
         await runSidecarWriter(messageId);
     } catch (err) {
         console.error('[TunnelVision] Sidecar post-gen writer error:', err);
+    } finally {
+        _writerRunning = false;
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ import { initActivityFeed } from './activity-feed.js';
 import { initCommands } from './commands.js';
 import { initAutoSummary } from './auto-summary.js';
 import { initPostTurnProcessor } from './post-turn-processor.js';
+import { initWorldState } from './world-state.js';
+import { initSmartContext } from './smart-context.js';
+import { initMemoryLifecycle } from './memory-lifecycle.js';
 import { runSidecarRetrieval, clearRetrievalPrompt } from './sidecar-retrieval.js';
 import { runSidecarWriter, revertMessageSnapshots, revertInvalidSnapshots, hydrateSnapshots } from './sidecar-writer.js';
 import { separateConditions, isEvaluableCondition, formatCondition, EVALUABLE_TYPES, CONDITION_LABELS, getKeywordProbability, setKeywordProbability } from './conditions.js';
@@ -80,6 +83,12 @@ async function init() {
 
     // Wire up post-turn processor (tracker updates, fact extraction, scene archiving)
     initPostTurnProcessor();
+
+    // Wire up rolling world state, smart context, and memory lifecycle —
+    // each is a no-op per event until its own *Enabled setting is turned on.
+    initWorldState();
+    initSmartContext();
+    initMemoryLifecycle();
 
     // Inject condition editor into ST's base lorebook editor
     initWIConditionInjector();

--- a/post-turn-processor.js
+++ b/post-turn-processor.js
@@ -878,7 +878,7 @@ async function archiveScene(targetBook, chat, sceneChange, chatId) {
       // Hide old-scene messages and advance watermark with the correct
       // range (watermark+1 → sceneEndIdx), not the full-chat tail.
       try {
-        await hideSummarizedMessages(undefined, { endIndex: sceneEndIdx });
+        await hideSummarizedMessages(undefined, watermark + 1, sceneEndIdx);
       } catch (e) {
         console.warn("[TunnelVision] Scene archive hide failed:", e);
       }
@@ -1045,7 +1045,7 @@ export async function updateTrackers(trackers, recentExcerpt, chatId) {
     const hashes = getTrackerHashes();
 
     for (const update of updates) {
-      if (!update?.uid || !update?.content) continue;
+      if (update?.uid === undefined || update?.uid === null || !update?.content) continue;
 
       const tracker = trackerMap.get(Number(update.uid));
       if (!tracker) continue;
@@ -1065,6 +1065,11 @@ export async function updateTrackers(trackers, recentExcerpt, chatId) {
           `[TunnelVision] Tracker "${tracker.title}" (UID ${tracker.uid}) was modified externally — rebasing post-turn update on latest saved content`,
         );
         setTrackerHash(tracker.book, tracker.uid, currentHash);
+        result.staleSkips.push({
+          uid: tracker.uid,
+          book: tracker.book,
+          title: tracker.title,
+        });
       }
 
       // Large-update guard: flag updates that change >60% of content
@@ -1570,9 +1575,22 @@ async function rollbackLastPostTurn() {
 
 // ── Event Handlers ───────────────────────────────────────────────
 
-function onAiMessageReceived() {
+function onAiMessageReceived(messageId, type) {
   const settings = getSettings();
   if (!settings.postTurnEnabled || settings.globalEnabled === false) return;
+
+  // continue/append/first_message/command generations reuse or extend the
+  // last message rather than swiping it — the length-based heuristic below
+  // would misdetect them as swipes. Only 'swipe' should be treated as a swipe.
+  if (
+    type === "continue" ||
+    type === "append" ||
+    type === "appendFinal" ||
+    type === "first_message" ||
+    type === "command"
+  ) {
+    return;
+  }
 
   const chatId = getChatId();
 
@@ -1595,7 +1613,7 @@ function onAiMessageReceived() {
     _chatRef.lastChatLength = Math.max(chatLength - 1, 0);
   }
 
-  const isSwipe = chatLength > 0 && chatLength <= _chatRef.lastChatLength;
+  const isSwipe = type === "swipe";
 
   if (isSwipe) {
     _chatRef.lastChatLength = chatLength;

--- a/settings.html
+++ b/settings.html
@@ -267,6 +267,18 @@
                             <textarea id="tv_background_prompt_addendum" class="tv-textarea" rows="4" placeholder="Optional provider/model instructions for background TunnelVision calls."></textarea>
                         </div>
 
+                        <!-- ═══ LLM Call Timeout ═══ -->
+                        <div class="tv-adv-section">
+                            <div class="tv-adv-section-title">Background LLM Call Timeout</div>
+                            <div class="tv-help-text" style="margin-bottom: 8px;">
+                                How long to wait for a single background LLM call (tree building, world state, smart context, memory lifecycle, post-turn processing) before retrying. Does not affect the main chat generation.
+                            </div>
+                            <div class="tv-number-row">
+                                <input id="tv_llm_call_timeout" type="number" class="tv-number-input" min="10" max="600" step="5" value="120" />
+                                <span class="tv-number-label">seconds</span>
+                            </div>
+                        </div>
+
                         <!-- ═══ Search Mode ═══ -->
                         <div class="tv-adv-section">
                             <div class="tv-adv-section-title">Search Mode</div>
@@ -340,6 +352,18 @@
                             <div class="tv-adv-section-title">Prompt Injection</div>
                             <div class="tv-help-text" style="margin-bottom: 8px;">
                                 Controls where and how TunnelVision injects its prompts into the conversation. Position and depth determine where the prompt lands in the message list the AI sees.
+                            </div>
+
+                            <!-- Total Injection Budget -->
+                            <div style="margin-bottom: 12px;">
+                                <label class="tv-label" for="tv_total_injection_budget">Total Injection Budget (characters)</label>
+                                <div class="tv-number-row">
+                                    <input id="tv_total_injection_budget" type="number" class="tv-number-input" min="0" max="100000" step="500" value="0" />
+                                    <span class="tv-number-label">chars (0 = unlimited)</span>
+                                </div>
+                                <div class="tv-help-text" style="margin-top: 4px;">
+                                    Caps the combined size of the mandatory-tools, world state, smart context, and notebook prompts. When the combined text would exceed this, prompts are trimmed in priority order (mandatory &gt; world state &gt; smart context &gt; notebook). 0 disables the cap.
+                                </div>
                             </div>
 
                             <!-- Mandatory Tool Calls -->
@@ -877,6 +901,199 @@
                                 <input type="text" id="tv_embedding_model" class="tv-text-input" style="margin-bottom: 6px;" placeholder="Model (e.g. text-embedding-3-small)" />
                                 <button id="tv_embedding_test" class="menu_button" type="button">Test Connection</button>
                             </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Rolling World State -->
+                <div class="tv-card">
+                    <div class="tv-card-header tv-card-header-collapsible" id="tv_world_state_header">
+                        <i class="fa-solid fa-globe"></i>
+                        <span>Rolling World State</span>
+                        <i class="fa-solid fa-chevron-down tv-collapse-icon"></i>
+                    </div>
+                    <div class="tv-card-body" style="display:none;">
+                        <div class="tv-help-text" style="margin-bottom: 8px;">
+                            Maintains a single living document (current scene, active threads, off-screen activity, key character states) that's periodically updated via a background LLM call and injected into context every turn. Unlike auto-summary, this is a snapshot, not an archive.
+                        </div>
+                        <label class="tv-toggle">
+                            <input id="tv_world_state_enabled" type="checkbox" />
+                            <span class="tv-toggle-slider"></span>
+                            <span class="tv-toggle-label">Enable Rolling World State</span>
+                        </label>
+                        <div id="tv_world_state_fields" style="display: none; margin-top: 10px;">
+                            <div style="display: flex; gap: 8px; align-items: center; margin-bottom: 8px;">
+                                <div style="flex: 1;">
+                                    <label class="tv-label" for="tv_world_state_interval">Update Interval (messages)</label>
+                                    <input type="number" id="tv_world_state_interval" class="tv-number-input" min="2" max="100" step="1" value="10" />
+                                </div>
+                                <div style="flex: 1;">
+                                    <label class="tv-label" for="tv_world_state_max_chars">Max Injection (chars)</label>
+                                    <input type="number" id="tv_world_state_max_chars" class="tv-number-input" min="500" max="20000" step="500" value="3000" />
+                                </div>
+                            </div>
+                            <div class="tv-prompt-inject-block" style="margin-bottom: 8px;">
+                                <div style="margin-bottom: 6px;"><strong>Injection Placement</strong></div>
+                                <div class="tv-prompt-inject-controls" style="display: flex; gap: 8px; align-items: center;">
+                                    <select id="tv_world_state_position" class="tv-select" style="width: auto;">
+                                        <option value="in_chat">In Chat</option>
+                                        <option value="in_prompt">In System Prompt</option>
+                                    </select>
+                                    <div class="tv-number-row" id="tv_world_state_depth_row" style="margin: 0;">
+                                        <label class="tv-number-label" for="tv_world_state_depth" style="margin: 0;">Depth:</label>
+                                        <input id="tv_world_state_depth" type="number" class="tv-number-input" min="0" max="50" step="1" value="2" style="width: 50px;" />
+                                    </div>
+                                    <select id="tv_world_state_role" class="tv-select" style="width: auto;">
+                                        <option value="system">System</option>
+                                        <option value="user">User</option>
+                                        <option value="assistant">Assistant</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="tv-adv-subsection" style="margin-top: 8px;">
+                                <label class="tv-label" for="tv_world_state_injection_override">Injection Header Override</label>
+                                <textarea id="tv_world_state_injection_override" class="tv-textarea" rows="2" placeholder="Leave empty to use the default framing text."></textarea>
+                                <div style="text-align: right; margin-top: 4px;">
+                                    <button id="tv_world_state_injection_reset" class="tv-btn tv-btn-sm" title="Reset to default" type="button">Reset</button>
+                                </div>
+                            </div>
+                            <div class="tv-adv-subsection" style="margin-top: 8px;">
+                                <label class="tv-label" for="tv_world_state_update_override">Update Instructions Override</label>
+                                <textarea id="tv_world_state_update_override" class="tv-textarea" rows="3" placeholder="Leave empty to use the default update instructions."></textarea>
+                                <div style="text-align: right; margin-top: 4px;">
+                                    <button id="tv_world_state_update_reset" class="tv-btn tv-btn-sm" title="Reset to default" type="button">Reset</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Smart Context -->
+                <div class="tv-card">
+                    <div class="tv-card-header tv-card-header-collapsible" id="tv_smart_context_header">
+                        <i class="fa-solid fa-bullseye"></i>
+                        <span>Smart Context</span>
+                        <i class="fa-solid fa-chevron-down tv-collapse-icon"></i>
+                    </div>
+                    <div class="tv-card-body" style="display:none;">
+                        <div class="tv-help-text" style="margin-bottom: 8px;">
+                            Scans recent chat for character/entity mentions and injects a relevance-scored slice of matching lorebook entries every turn, independent of the tree search tool.
+                        </div>
+                        <label class="tv-toggle">
+                            <input id="tv_smart_context_enabled" type="checkbox" />
+                            <span class="tv-toggle-slider"></span>
+                            <span class="tv-toggle-label">Enable Smart Context</span>
+                        </label>
+                        <div id="tv_smart_context_fields" style="display: none; margin-top: 10px;">
+                            <div style="display: flex; gap: 8px; align-items: center; margin-bottom: 8px;">
+                                <div style="flex: 1;">
+                                    <label class="tv-label" for="tv_smart_context_lookback">Lookback (messages)</label>
+                                    <input type="number" id="tv_smart_context_lookback" class="tv-number-input" min="1" max="50" step="1" value="6" />
+                                </div>
+                                <div style="flex: 1;">
+                                    <label class="tv-label" for="tv_smart_context_max_entries">Max Entries</label>
+                                    <input type="number" id="tv_smart_context_max_entries" class="tv-number-input" min="1" max="50" step="1" value="8" />
+                                </div>
+                            </div>
+                            <div style="margin-bottom: 8px;">
+                                <label class="tv-label" for="tv_smart_context_max_chars">Max Injection (chars)</label>
+                                <input type="number" id="tv_smart_context_max_chars" class="tv-number-input" min="500" max="20000" step="500" value="4000" />
+                            </div>
+                            <div class="tv-prompt-inject-block">
+                                <div style="margin-bottom: 6px;"><strong>Injection Placement</strong></div>
+                                <div class="tv-prompt-inject-controls" style="display: flex; gap: 8px; align-items: center;">
+                                    <select id="tv_smart_context_position" class="tv-select" style="width: auto;">
+                                        <option value="in_chat">In Chat</option>
+                                        <option value="in_prompt">In System Prompt</option>
+                                    </select>
+                                    <div class="tv-number-row" id="tv_smart_context_depth_row" style="margin: 0;">
+                                        <label class="tv-number-label" for="tv_smart_context_depth" style="margin: 0;">Depth:</label>
+                                        <input id="tv_smart_context_depth" type="number" class="tv-number-input" min="0" max="50" step="1" value="3" style="width: 50px;" />
+                                    </div>
+                                    <select id="tv_smart_context_role" class="tv-select" style="width: auto;">
+                                        <option value="system">System</option>
+                                        <option value="user">User</option>
+                                        <option value="assistant">Assistant</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Memory Lifecycle -->
+                <div class="tv-card">
+                    <div class="tv-card-header tv-card-header-collapsible" id="tv_lifecycle_header">
+                        <i class="fa-solid fa-recycle"></i>
+                        <span>Memory Lifecycle</span>
+                        <i class="fa-solid fa-chevron-down tv-collapse-icon"></i>
+                    </div>
+                    <div class="tv-card-body" style="display:none;">
+                        <div class="tv-help-text" style="margin-bottom: 8px;">
+                            Periodic background maintenance over your lorebooks: merges near-duplicate entries, compresses verbose ones, and reorganizes the tree as it grows. Runs on an adaptive interval driven by recent lorebook activity.
+                        </div>
+                        <label class="tv-toggle">
+                            <input id="tv_lifecycle_enabled" type="checkbox" />
+                            <span class="tv-toggle-slider"></span>
+                            <span class="tv-toggle-label">Enable Memory Lifecycle</span>
+                        </label>
+                        <div id="tv_lifecycle_fields" style="display: none; margin-top: 10px;">
+                            <div style="margin-bottom: 8px;">
+                                <label class="tv-label" for="tv_lifecycle_interval">Base Interval (messages)</label>
+                                <input type="number" id="tv_lifecycle_interval" class="tv-number-input" min="5" max="200" step="5" value="30" />
+                                <div class="tv-help-text" style="margin-top: 4px;">
+                                    The actual interval adapts up or down from this baseline based on recent duplicate/contradiction activity.
+                                </div>
+                            </div>
+                            <label class="tv-toggle-row">
+                                <input id="tv_lifecycle_consolidate" type="checkbox" />
+                                <span>Consolidate — merge near-duplicate entries</span>
+                            </label>
+                            <label class="tv-toggle-row" style="margin-top: 6px;">
+                                <input id="tv_lifecycle_compress" type="checkbox" />
+                                <span>Compress — shorten verbose entries</span>
+                            </label>
+                            <label class="tv-toggle-row" style="margin-top: 6px;">
+                                <input id="tv_lifecycle_reorganize" type="checkbox" />
+                                <span>Reorganize — rebalance the tree as it grows</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Post-Turn Processor -->
+                <div class="tv-card">
+                    <div class="tv-card-header tv-card-header-collapsible" id="tv_post_turn_header">
+                        <i class="fa-solid fa-brain"></i>
+                        <span>Post-Turn Processor</span>
+                        <i class="fa-solid fa-chevron-down tv-collapse-icon"></i>
+                    </div>
+                    <div class="tv-card-body" style="display:none;">
+                        <div class="tv-help-text" style="margin-bottom: 8px;">
+                            After each AI response, runs a background pass that extracts new facts, updates tracker entries, and archives the previous scene when a scene change is detected. Separate from the Sidecar auto-write above — this pass is more structured and tracker-aware.
+                        </div>
+                        <label class="tv-toggle">
+                            <input id="tv_post_turn_enabled" type="checkbox" />
+                            <span class="tv-toggle-slider"></span>
+                            <span class="tv-toggle-label">Enable Post-Turn Processor</span>
+                        </label>
+                        <div id="tv_post_turn_fields" style="display: none; margin-top: 10px;">
+                            <div style="margin-bottom: 8px;">
+                                <label class="tv-label" for="tv_post_turn_cooldown">Cooldown (messages between runs)</label>
+                                <input type="number" id="tv_post_turn_cooldown" class="tv-number-input" min="1" max="50" step="1" value="1" />
+                            </div>
+                            <label class="tv-toggle-row">
+                                <input id="tv_post_turn_update_trackers" type="checkbox" />
+                                <span>Update Trackers</span>
+                            </label>
+                            <label class="tv-toggle-row" style="margin-top: 6px;">
+                                <input id="tv_post_turn_extract_facts" type="checkbox" />
+                                <span>Extract Facts</span>
+                            </label>
+                            <label class="tv-toggle-row" style="margin-top: 6px;">
+                                <input id="tv_post_turn_scene_archive" type="checkbox" />
+                                <span>Archive Scene on Transition</span>
+                            </label>
                         </div>
                     </div>
                 </div>

--- a/sidecar-retrieval.js
+++ b/sidecar-retrieval.js
@@ -453,23 +453,32 @@ export async function runSidecarRetrieval(type = null) {
     const settings = getSettings();
 
     // Guard: must be enabled and sidecar must be configured
-    if (!settings.sidecarAutoRetrieval) return;
+    if (!settings.sidecarAutoRetrieval) {
+        clearRetrievalPrompt(settings);
+        return;
+    }
     if (isCircuitOpen()) {
         console.debug('[TunnelVision] Sidecar auto-retrieval: circuit breaker open — skipping');
+        clearRetrievalPrompt(settings);
         return;
     }
     if (!isSidecarConfigured()) {
         console.debug('[TunnelVision] Sidecar auto-retrieval enabled but no sidecar configured — skipping');
+        clearRetrievalPrompt(settings);
         return;
     }
 
     const activeBooks = getReadableBooks();
-    if (activeBooks.length === 0) return;
+    if (activeBooks.length === 0) {
+        clearRetrievalPrompt(settings);
+        return;
+    }
 
     // Build tree overview
     const treeOverview = buildSidecarTreeOverview();
     if (!treeOverview.trim()) {
         console.debug('[TunnelVision] Sidecar auto-retrieval: no tree content to navigate');
+        clearRetrievalPrompt(settings);
         return;
     }
 
@@ -478,6 +487,7 @@ export async function runSidecarRetrieval(type = null) {
     const recentChat = extractRecentChat(contextMessages, type === 'swipe');
     if (!recentChat.trim()) {
         console.debug('[TunnelVision] Sidecar auto-retrieval: no recent chat context');
+        clearRetrievalPrompt(settings);
         return;
     }
 
@@ -596,7 +606,7 @@ export async function runSidecarRetrieval(type = null) {
  * Clear the sidecar retrieval prompt (no content to inject).
  * @param {Object} settings
  */
-function clearRetrievalPrompt(settings) {
+export function clearRetrievalPrompt(settings) {
     lastInjectedNodeIds = [];
     const position = mapPosition(settings.mandatoryPromptPosition);
     const depth = settings.mandatoryPromptDepth ?? 1;

--- a/sidecar-writer.js
+++ b/sidecar-writer.js
@@ -24,7 +24,7 @@ import {
     getAllEntryUids,
     getSettings,
 } from './tree-store.js';
-import { getReadableBooks, getWritableBooks, getBookListWithDescriptions, checkToolConfirmation, REMEMBER_NAME, UPDATE_NAME, FORGET_NAME, SUMMARIZE_NAME, REORGANIZE_NAME, MERGESPLIT_NAME } from './tool-registry.js';
+import { getReadableBooks, getWritableBooks, getBookListWithDescriptions, checkToolConfirmation, resolveTargetBook, REMEMBER_NAME, UPDATE_NAME, FORGET_NAME, SUMMARIZE_NAME, REORGANIZE_NAME, MERGESPLIT_NAME } from './tool-registry.js';
 import { isSidecarConfigured, isCircuitOpen, sidecarGenerate, getSidecarModelLabel } from './llm-sidecar.js';
 import { getDefinition as getRememberDef } from './tools/remember.js';
 import { getDefinition as getUpdateDef } from './tools/update.js';
@@ -96,8 +96,13 @@ async function takeSnapshots(snapshotKey, ops) {
     };
 
     for (const op of ops) {
-        if (!op.lorebook) continue;
-        const bookData = await loadWorldInfo(op.lorebook);
+        // op.lorebook may be unset when the sidecar leaves book selection to
+        // auto-resolution — resolve it the same way the tool actions will,
+        // otherwise we silently skip the snapshot for the book that actually
+        // gets mutated and revertMessageSnapshots has nothing to restore.
+        const { book: lorebook } = resolveTargetBook(op.lorebook);
+        if (!lorebook) continue;
+        const bookData = await loadWorldInfo(lorebook);
         if (!bookData?.entries) continue;
 
         if (op.type === 'update' || op.type === 'merge' || op.type === 'forget' || op.type === 'split') {
@@ -106,19 +111,19 @@ async function takeSnapshots(snapshotKey, ops) {
                 if (uid === undefined) continue;
                 const entry = findEntryByUid(bookData.entries, uid);
                 if (entry) {
-                    const key = `${op.lorebook}:${uid}`;
+                    const key = `${lorebook}:${uid}`;
                     if (!snapshots.modifiedEntries[key]) {
                         snapshots.modifiedEntries[key] = JSON.parse(JSON.stringify(entry));
                     }
                 }
             }
         }
-        
+
         // Always snapshot the tree state if we might change it
-        if (!snapshots.treeState[op.lorebook]) {
-            const tree = getTree(op.lorebook);
+        if (!snapshots.treeState[lorebook]) {
+            const tree = getTree(lorebook);
             if (tree?.root) {
-                snapshots.treeState[op.lorebook] = JSON.parse(JSON.stringify(tree.root));
+                snapshots.treeState[lorebook] = JSON.parse(JSON.stringify(tree.root));
             }
         }
     }
@@ -880,7 +885,7 @@ async function executeWriteOps(ops, reasoning = '', messageId = null) {
                 const approved = await checkToolConfirmation(toolName, op);
                 if (!approved) {
                     console.log(`[TunnelVision] Sidecar write denied by user: ${op.type} "${op.title || op.uid || ''}"`)
-                    results.push({ op, success: false, result: 'Denied by user' });
+                    results.push(`FAIL [${op.type}]: Denied by user`);
                     failed++;
                     continue;
                 }

--- a/style.css
+++ b/style.css
@@ -1332,6 +1332,24 @@
     100% { opacity: 0.6; transform: scale(1); }
 }
 
+/* Indicates a background task (post-turn, world-state, lifecycle) is running */
+.tv-float-bg-active {
+    border-color: rgba(108, 92, 231, 0.7) !important;
+    box-shadow: 0 0 14px rgba(108, 92, 231, 0.35) !important;
+    animation: tv-bg-spin 1.2s linear infinite;
+}
+
+.tv-float-bg-active > i {
+    animation: tv-sidecar-icon-pulse 1.2s ease-in-out infinite;
+    color: #6c5ce7 !important;
+}
+
+@keyframes tv-bg-spin {
+    0%   { box-shadow: 0 0 8px rgba(108, 92, 231, 0.2); }
+    50%  { box-shadow: 0 0 18px rgba(108, 92, 231, 0.5); }
+    100% { box-shadow: 0 0 8px rgba(108, 92, 231, 0.2); }
+}
+
 /* Panel */
 .tv-float-panel {
     position: fixed;

--- a/tests/__mocks__/st-chats.js
+++ b/tests/__mocks__/st-chats.js
@@ -1,0 +1,1 @@
+export const hideChatMessageRange = async () => {};

--- a/tests/__mocks__/st-group-chats.js
+++ b/tests/__mocks__/st-group-chats.js
@@ -1,0 +1,2 @@
+export const selected_group = null;
+export const groups = [];

--- a/tests/__mocks__/st-power-user.js
+++ b/tests/__mocks__/st-power-user.js
@@ -1,0 +1,1 @@
+export const power_user = {};

--- a/tests/diagnostics.test.js
+++ b/tests/diagnostics.test.js
@@ -1,3 +1,5 @@
+/* @vitest-environment jsdom */
+
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const getMockState = () => globalThis.__tvDiagnosticsMockState;
@@ -20,7 +22,16 @@ vi.mock('../tree-store.js', () => ({
         return result;
     }),
     findNodeById: vi.fn(() => null),
-    getSettings: vi.fn(() => getMockState().settings),
+    // Real getSettings() backfills missing keys via ensureSettings() — mirror that
+    // here (in place, preserving object identity) so tests that don't set
+    // enabledLorebooks/trees explicitly don't crash, while mutations diagnostics.js
+    // makes to settings.trackerUids etc. are still visible on state.settings.
+    getSettings: vi.fn(() => {
+        const settings = getMockState().settings;
+        if (settings.enabledLorebooks === undefined) settings.enabledLorebooks = {};
+        if (settings.trees === undefined) settings.trees = {};
+        return settings;
+    }),
     saveTree: vi.fn((bookName, tree) => {
         getMockState().savedTrees.push({ bookName, tree });
     }),
@@ -75,6 +86,10 @@ vi.mock('../../../world-info.js', async () => {
         get world_names() {
             return getMockState().worldNames;
         },
+        // The aliased st-world-info.js stub's loadWorldInfo always returns
+        // `{ entries: {} }` regardless of bookName, which silently makes every
+        // tracker UID look stale. Route it through the per-test lorebook fixtures.
+        loadWorldInfo: vi.fn(async (bookName) => getMockState().lorebooks.get(bookName) || null),
     };
 });
 
@@ -83,7 +98,7 @@ import { runDiagnostics } from '../diagnostics.js';
 function resetMockState() {
     globalThis.__tvDiagnosticsMockState = {
         activeBooks: [],
-        settings: { trackerUids: {} },
+        settings: { trackerUids: {}, enabledLorebooks: {}, trees: {} },
         worldNames: [],
         lorebooks: new Map(),
         savedTrees: [],

--- a/tests/post-turn-processor.test.js
+++ b/tests/post-turn-processor.test.js
@@ -256,7 +256,9 @@ describe('updateTrackers', () => {
         const result = await updateTrackers(trackers, 'Sophia steadies herself.', 'test-chat');
 
         expect(result.updated).toBe(1);
-        expect(result.staleSkips).toEqual([]);
+        expect(result.staleSkips).toEqual([
+            { uid: 7, book: 'test-book', title: '[Tracker: Sophia Fuchs]' },
+        ]);
         expect(updateEntry).toHaveBeenCalledWith('test-book', 7, {
             content: '## Current Status\nMood: alert',
             _source: 'post-turn',

--- a/tests/tree-store.test.js
+++ b/tests/tree-store.test.js
@@ -8,7 +8,6 @@ import {
     findNodeById,
     getSettings,
     getTrackerUids,
-    invalidateNodeIndex,
     isSummaryTitle,
     isTrackerTitle,
     removeNode,
@@ -39,24 +38,6 @@ describe('getSettings normalization', () => {
         expect(settings.llmBuildDetail).toBe('lite');
         expect(settings.trackerUids).toEqual({});
         expect(settings.ephemeralToolFilter).toEqual(SETTING_DEFAULTS.ephemeralToolFilter);
-    });
-
-    it('does not normalize tracker uid lists during settings initialization; tracker cleanup happens via tracker-specific helpers', () => {
-        extension_settings.tunnelvision = {
-            trackerUids: {
-                Alpha: ['5', 2, 'x', 5, 3, null],
-                Empty: [],
-                Invalid: 'nope',
-            },
-        };
-
-        const settings = getSettings();
-
-        expect(settings.trackerUids).toEqual({
-            Alpha: ['5', 2, 'x', 5, 3, null],
-            Empty: [],
-            Invalid: 'nope',
-        });
     });
 });
 
@@ -182,19 +163,6 @@ describe('findNodeById', () => {
         expect(findNodeById(null, 'any')).toBeNull();
     });
 
-    it('returns stale results until the node index is invalidated', () => {
-        expect(findNodeById(tree, 'child-2')).toBe(tree.children[1]);
-
-        tree.children[1].id = 'child-2-renamed';
-
-        expect(findNodeById(tree, 'child-2')).toBe(tree.children[1]);
-        expect(findNodeById(tree, 'child-2-renamed')).toBeNull();
-
-        invalidateNodeIndex(tree);
-
-        expect(findNodeById(tree, 'child-2')).toBeNull();
-        expect(findNodeById(tree, 'child-2-renamed')).toBe(tree.children[1]);
-    });
 });
 
 describe('saveTree normalization', () => {

--- a/tree-store.js
+++ b/tree-store.js
@@ -343,6 +343,34 @@ export const SETTING_DEFAULTS = {
     postTurnUpdateTrackers: true,
     postTurnExtractFacts: true,
     postTurnSceneArchive: true,
+    // Rolling world state (living document, updated periodically, injected every turn)
+    worldStateEnabled: false,
+    worldStateInterval: 10,
+    worldStateDepth: 2,
+    worldStateMaxChars: 3000,
+    worldStatePosition: 'in_chat',
+    worldStateRole: 'system',
+    worldStateInjectionOverride: '',
+    worldStateUpdateOverride: '',
+    // Smart context (chat-mention-driven relevance injection, separate from tree search)
+    smartContextEnabled: false,
+    smartContextDepth: 3,
+    smartContextLookback: 6,
+    smartContextMaxChars: 4000,
+    smartContextMaxEntries: 8,
+    smartContextPosition: 'in_chat',
+    smartContextRole: 'system',
+    // Memory lifecycle (periodic dedup/compress/reorganize maintenance)
+    lifecycleEnabled: false,
+    lifecycleInterval: 30,
+    lifecycleCompress: true,
+    lifecycleConsolidate: true,
+    lifecycleReorganize: true,
+    // Combined char budget across mandatory/worldState/smartContext/notebook prompts. 0 = unlimited.
+    totalInjectionBudget: 0,
+    // Per-call timeout for background LLM calls (tree building, world state, smart context,
+    // memory lifecycle, post-turn), in ms.
+    llmCallTimeout: 120000,
     // Per-lorebook permissions: { bookName: 'read_write' | 'read_only' | 'write_only' }
     bookPermissions: {},
     // Per-lorebook injection mode: { bookName: 'sidecar' | 'native' }

--- a/tree-store.js
+++ b/tree-store.js
@@ -746,7 +746,9 @@ export function isTrackerTitle(title) {
     return TRACKER_TITLE_PREFIX.test(String(title || '').trim());
 }
 
-const SUMMARY_TITLE_PREFIX = /^\[(?:scene\s+)?summary[^\]]*\]/i;
+// Matches [Summary], [Scene Summary], [Act Summary], [Act Summary — ...] and
+// [Story Summary] — the titles summary-hierarchy.js actually creates.
+const SUMMARY_TITLE_PREFIX = /^\[(?:(?:scene|act|story)\s+)?summary[^\]]*\]/i;
 
 export function isSummaryTitle(title) {
     return SUMMARY_TITLE_PREFIX.test(String(title || '').trim());

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -227,6 +227,61 @@ export function bindUIEvents() {
     $('#tv_book_permission').on('change', onBookPermissionChange);
     $('#tv_book_injection_mode').on('change', onBookInjectionModeChange);
 
+    // Rolling World State collapsible header + settings
+    $('#tv_world_state_header').on('click', function () {
+        $(this).toggleClass('expanded');
+        $(this).next('.tv-card-body').slideToggle(200);
+    });
+    $('#tv_world_state_enabled').on('change', onWorldStateToggle);
+    $('#tv_world_state_interval').on('change', onWorldStateIntervalChange);
+    $('#tv_world_state_max_chars').on('change', onWorldStateMaxCharsChange);
+    $('#tv_world_state_position').on('change', onWorldStateInjectionMetaChange);
+    $('#tv_world_state_depth').on('change', onWorldStateInjectionMetaChange);
+    $('#tv_world_state_role').on('change', onWorldStateInjectionMetaChange);
+    $('#tv_world_state_injection_override').on('change', onWorldStateInjectionOverrideChange);
+    $('#tv_world_state_injection_reset').on('click', onWorldStateInjectionReset);
+    $('#tv_world_state_update_override').on('change', onWorldStateUpdateOverrideChange);
+    $('#tv_world_state_update_reset').on('click', onWorldStateUpdateReset);
+
+    // Smart Context collapsible header + settings
+    $('#tv_smart_context_header').on('click', function () {
+        $(this).toggleClass('expanded');
+        $(this).next('.tv-card-body').slideToggle(200);
+    });
+    $('#tv_smart_context_enabled').on('change', onSmartContextToggle);
+    $('#tv_smart_context_lookback').on('change', onSmartContextLookbackChange);
+    $('#tv_smart_context_max_entries').on('change', onSmartContextMaxEntriesChange);
+    $('#tv_smart_context_max_chars').on('change', onSmartContextMaxCharsChange);
+    $('#tv_smart_context_position').on('change', onSmartContextInjectionMetaChange);
+    $('#tv_smart_context_depth').on('change', onSmartContextInjectionMetaChange);
+    $('#tv_smart_context_role').on('change', onSmartContextInjectionMetaChange);
+
+    // Memory Lifecycle collapsible header + settings
+    $('#tv_lifecycle_header').on('click', function () {
+        $(this).toggleClass('expanded');
+        $(this).next('.tv-card-body').slideToggle(200);
+    });
+    $('#tv_lifecycle_enabled').on('change', onLifecycleToggle);
+    $('#tv_lifecycle_interval').on('change', onLifecycleIntervalChange);
+    $('#tv_lifecycle_consolidate').on('change', onLifecycleConsolidateToggle);
+    $('#tv_lifecycle_compress').on('change', onLifecycleCompressToggle);
+    $('#tv_lifecycle_reorganize').on('change', onLifecycleReorganizeToggle);
+
+    // Post-Turn Processor collapsible header + settings
+    $('#tv_post_turn_header').on('click', function () {
+        $(this).toggleClass('expanded');
+        $(this).next('.tv-card-body').slideToggle(200);
+    });
+    $('#tv_post_turn_enabled').on('change', onPostTurnToggle);
+    $('#tv_post_turn_cooldown').on('change', onPostTurnCooldownChange);
+    $('#tv_post_turn_update_trackers').on('change', onPostTurnUpdateTrackersToggle);
+    $('#tv_post_turn_extract_facts').on('change', onPostTurnExtractFactsToggle);
+    $('#tv_post_turn_scene_archive').on('change', onPostTurnSceneArchiveToggle);
+
+    // Global injection budget + background LLM call timeout
+    $('#tv_total_injection_budget').on('change', onTotalInjectionBudgetChange);
+    $('#tv_llm_call_timeout').on('change', onLlmCallTimeoutChange);
+
     // Backup & Restore collapsible header
     $('#tv_backup_header').on('click', function () {
         $(this).toggleClass('expanded');
@@ -358,6 +413,53 @@ export function refreshUI() {
 
     // Sync sidecar/embedding profiles + sampler controls
     populateSidecarProfiles();
+
+    // Sync rolling world state
+    const worldStateEnabled = settings.worldStateEnabled === true;
+    $('#tv_world_state_enabled').prop('checked', worldStateEnabled);
+    $('#tv_world_state_fields').toggle(worldStateEnabled);
+    $('#tv_world_state_interval').val(settings.worldStateInterval ?? 10);
+    $('#tv_world_state_max_chars').val(settings.worldStateMaxChars ?? 3000);
+    $('#tv_world_state_position').val(settings.worldStatePosition || 'in_chat');
+    $('#tv_world_state_depth').val(settings.worldStateDepth ?? 2);
+    $('#tv_world_state_role').val(settings.worldStateRole || 'system');
+    $('#tv_world_state_depth_row').toggle((settings.worldStatePosition || 'in_chat') === 'in_chat');
+    $('#tv_world_state_injection_override').val(settings.worldStateInjectionOverride || '');
+    $('#tv_world_state_update_override').val(settings.worldStateUpdateOverride || '');
+
+    // Sync smart context
+    const smartContextEnabled = settings.smartContextEnabled === true;
+    $('#tv_smart_context_enabled').prop('checked', smartContextEnabled);
+    $('#tv_smart_context_fields').toggle(smartContextEnabled);
+    $('#tv_smart_context_lookback').val(settings.smartContextLookback ?? 6);
+    $('#tv_smart_context_max_entries').val(settings.smartContextMaxEntries ?? 8);
+    $('#tv_smart_context_max_chars').val(settings.smartContextMaxChars ?? 4000);
+    $('#tv_smart_context_position').val(settings.smartContextPosition || 'in_chat');
+    $('#tv_smart_context_depth').val(settings.smartContextDepth ?? 3);
+    $('#tv_smart_context_role').val(settings.smartContextRole || 'system');
+    $('#tv_smart_context_depth_row').toggle((settings.smartContextPosition || 'in_chat') === 'in_chat');
+
+    // Sync memory lifecycle
+    const lifecycleEnabled = settings.lifecycleEnabled === true;
+    $('#tv_lifecycle_enabled').prop('checked', lifecycleEnabled);
+    $('#tv_lifecycle_fields').toggle(lifecycleEnabled);
+    $('#tv_lifecycle_interval').val(settings.lifecycleInterval ?? 30);
+    $('#tv_lifecycle_consolidate').prop('checked', settings.lifecycleConsolidate !== false);
+    $('#tv_lifecycle_compress').prop('checked', settings.lifecycleCompress !== false);
+    $('#tv_lifecycle_reorganize').prop('checked', settings.lifecycleReorganize !== false);
+
+    // Sync post-turn processor
+    const postTurnEnabled = settings.postTurnEnabled === true;
+    $('#tv_post_turn_enabled').prop('checked', postTurnEnabled);
+    $('#tv_post_turn_fields').toggle(postTurnEnabled);
+    $('#tv_post_turn_cooldown').val(settings.postTurnCooldown ?? 1);
+    $('#tv_post_turn_update_trackers').prop('checked', settings.postTurnUpdateTrackers !== false);
+    $('#tv_post_turn_extract_facts').prop('checked', settings.postTurnExtractFacts !== false);
+    $('#tv_post_turn_scene_archive').prop('checked', settings.postTurnSceneArchive !== false);
+
+    // Sync total injection budget + background LLM call timeout (stored in ms, shown in seconds)
+    $('#tv_total_injection_budget').val(settings.totalInjectionBudget ?? 0);
+    $('#tv_llm_call_timeout').val(Math.round((settings.llmCallTimeout ?? 120000) / 1000));
 
     populateLorebookDropdown();
     $('#tv_lorebook_controls').toggle(!!currentLorebook);
@@ -1091,6 +1193,201 @@ function onBookInjectionModeChange() {
     if (!currentLorebook) return;
     setBookInjectionMode(currentLorebook, $(this).val() || 'sidecar');
     registerTools();
+}
+
+// ─── Rolling World State ─────────────────────────────────────────
+
+function onWorldStateToggle() {
+    const settings = getSettings();
+    settings.worldStateEnabled = $(this).prop('checked');
+    $('#tv_world_state_fields').toggle(settings.worldStateEnabled);
+    saveSettingsDebounced();
+}
+
+function onWorldStateIntervalChange() {
+    const settings = getSettings();
+    settings.worldStateInterval = Number($(this).val()) || 10;
+    saveSettingsDebounced();
+}
+
+function onWorldStateMaxCharsChange() {
+    const settings = getSettings();
+    settings.worldStateMaxChars = Number($(this).val()) || 3000;
+    saveSettingsDebounced();
+}
+
+function onWorldStateInjectionMetaChange() {
+    const settings = getSettings();
+    const $el = $(this);
+    const field = ($el.attr('id') || '').replace('tv_world_state_', '');
+    if (field === 'position') {
+        settings.worldStatePosition = $el.val();
+        $('#tv_world_state_depth_row').toggle($el.val() === 'in_chat');
+    } else if (field === 'depth') {
+        const rawDepth = Number($el.val());
+        settings.worldStateDepth = Math.max(0, Math.round(Number.isFinite(rawDepth) ? rawDepth : 2));
+        $el.val(settings.worldStateDepth);
+    } else if (field === 'role') {
+        settings.worldStateRole = $el.val();
+    }
+    saveSettingsDebounced();
+}
+
+function onWorldStateInjectionOverrideChange() {
+    const settings = getSettings();
+    settings.worldStateInjectionOverride = $(this).val() || '';
+    saveSettingsDebounced();
+}
+
+function onWorldStateInjectionReset() {
+    const settings = getSettings();
+    settings.worldStateInjectionOverride = '';
+    $('#tv_world_state_injection_override').val('');
+    saveSettingsDebounced();
+}
+
+function onWorldStateUpdateOverrideChange() {
+    const settings = getSettings();
+    settings.worldStateUpdateOverride = $(this).val() || '';
+    saveSettingsDebounced();
+}
+
+function onWorldStateUpdateReset() {
+    const settings = getSettings();
+    settings.worldStateUpdateOverride = '';
+    $('#tv_world_state_update_override').val('');
+    saveSettingsDebounced();
+}
+
+// ─── Smart Context ───────────────────────────────────────────────
+
+function onSmartContextToggle() {
+    const settings = getSettings();
+    settings.smartContextEnabled = $(this).prop('checked');
+    $('#tv_smart_context_fields').toggle(settings.smartContextEnabled);
+    saveSettingsDebounced();
+}
+
+function onSmartContextLookbackChange() {
+    const settings = getSettings();
+    settings.smartContextLookback = Number($(this).val()) || 6;
+    saveSettingsDebounced();
+}
+
+function onSmartContextMaxEntriesChange() {
+    const settings = getSettings();
+    settings.smartContextMaxEntries = Number($(this).val()) || 8;
+    saveSettingsDebounced();
+}
+
+function onSmartContextMaxCharsChange() {
+    const settings = getSettings();
+    settings.smartContextMaxChars = Number($(this).val()) || 4000;
+    saveSettingsDebounced();
+}
+
+function onSmartContextInjectionMetaChange() {
+    const settings = getSettings();
+    const $el = $(this);
+    const field = ($el.attr('id') || '').replace('tv_smart_context_', '');
+    if (field === 'position') {
+        settings.smartContextPosition = $el.val();
+        $('#tv_smart_context_depth_row').toggle($el.val() === 'in_chat');
+    } else if (field === 'depth') {
+        const rawDepth = Number($el.val());
+        settings.smartContextDepth = Math.max(0, Math.round(Number.isFinite(rawDepth) ? rawDepth : 3));
+        $el.val(settings.smartContextDepth);
+    } else if (field === 'role') {
+        settings.smartContextRole = $el.val();
+    }
+    saveSettingsDebounced();
+}
+
+// ─── Memory Lifecycle ────────────────────────────────────────────
+
+function onLifecycleToggle() {
+    const settings = getSettings();
+    settings.lifecycleEnabled = $(this).prop('checked');
+    $('#tv_lifecycle_fields').toggle(settings.lifecycleEnabled);
+    saveSettingsDebounced();
+}
+
+function onLifecycleIntervalChange() {
+    const settings = getSettings();
+    settings.lifecycleInterval = Number($(this).val()) || 30;
+    saveSettingsDebounced();
+}
+
+function onLifecycleConsolidateToggle() {
+    const settings = getSettings();
+    settings.lifecycleConsolidate = $(this).prop('checked');
+    saveSettingsDebounced();
+}
+
+function onLifecycleCompressToggle() {
+    const settings = getSettings();
+    settings.lifecycleCompress = $(this).prop('checked');
+    saveSettingsDebounced();
+}
+
+function onLifecycleReorganizeToggle() {
+    const settings = getSettings();
+    settings.lifecycleReorganize = $(this).prop('checked');
+    saveSettingsDebounced();
+}
+
+// ─── Post-Turn Processor ─────────────────────────────────────────
+
+function onPostTurnToggle() {
+    const settings = getSettings();
+    settings.postTurnEnabled = $(this).prop('checked');
+    $('#tv_post_turn_fields').toggle(settings.postTurnEnabled);
+    saveSettingsDebounced();
+}
+
+function onPostTurnCooldownChange() {
+    const settings = getSettings();
+    settings.postTurnCooldown = Math.max(Number($(this).val()) || 1, 1);
+    $(this).val(settings.postTurnCooldown);
+    saveSettingsDebounced();
+}
+
+function onPostTurnUpdateTrackersToggle() {
+    const settings = getSettings();
+    settings.postTurnUpdateTrackers = $(this).prop('checked');
+    saveSettingsDebounced();
+}
+
+function onPostTurnExtractFactsToggle() {
+    const settings = getSettings();
+    settings.postTurnExtractFacts = $(this).prop('checked');
+    saveSettingsDebounced();
+}
+
+function onPostTurnSceneArchiveToggle() {
+    const settings = getSettings();
+    settings.postTurnSceneArchive = $(this).prop('checked');
+    saveSettingsDebounced();
+}
+
+// ─── Global Injection Budget + Background LLM Timeout ───────────
+
+function onTotalInjectionBudgetChange() {
+    const raw = Number($('#tv_total_injection_budget').val());
+    const clamped = Math.min(Math.max(Math.round(Number.isFinite(raw) ? raw : 0), 0), 100000);
+    $('#tv_total_injection_budget').val(clamped);
+    const settings = getSettings();
+    settings.totalInjectionBudget = clamped;
+    saveSettingsDebounced();
+}
+
+function onLlmCallTimeoutChange() {
+    const raw = Number($('#tv_llm_call_timeout').val());
+    const clampedSeconds = Math.min(Math.max(Math.round(raw) || 120, 10), 600);
+    $('#tv_llm_call_timeout').val(clampedSeconds);
+    const settings = getSettings();
+    settings.llmCallTimeout = clampedSeconds * 1000;
+    saveSettingsDebounced();
 }
 
 function populateSidecarProfiles() {

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -38,6 +38,7 @@ import { buildTreeFromMetadata, buildTreeWithLLM, generateSummariesForTree, inge
 import { testSidecarConnectivity, testEmbeddingConnectivity } from './llm-sidecar.js';
 import { registerTools, unregisterTools, getDefaultToolDescriptions, stripDynamicContent } from './tool-registry.js';
 import { runDiagnostics } from './diagnostics.js';
+import { clearRetrievalPrompt } from './sidecar-retrieval.js';
 import { applyRecurseLimit } from './index.js';
 import { refreshHiddenToolCallMessages } from './activity-feed.js';
 import { separateConditions, isEvaluableCondition, formatCondition, EVALUABLE_TYPES, CONDITION_LABELS, getKeywordProbability, setKeywordProbability } from './conditions.js';
@@ -249,7 +250,9 @@ export function refreshUI() {
 
     // Trigger active editor refresh if open
     if (activeEditorRefresh) {
-        activeEditorRefresh();
+        Promise.resolve(activeEditorRefresh()).catch((e) => {
+            console.error('[TunnelVision] Tree editor refresh failed:', e);
+        });
     }
 
     $('#tv_global_enabled').prop('checked', globalEnabled);
@@ -835,7 +838,10 @@ function onPromptInjectionChange() {
             settings.mandatoryPromptPosition = $el.val();
             $('#tv_mandatory_depth_row').toggle($el.val() === 'in_chat');
         } else if (field === 'depth') {
-            settings.mandatoryPromptDepth = Math.max(1, Math.round(Number($el.val()) || 1));
+            // min="0" is a legal depth (inject after the final message) — don't
+            // let a falsy `0` get coerced up to 1.
+            const rawDepth = Number($el.val());
+            settings.mandatoryPromptDepth = Math.max(0, Math.round(Number.isFinite(rawDepth) ? rawDepth : 1));
             $el.val(settings.mandatoryPromptDepth);
         } else if (field === 'role') {
             settings.mandatoryPromptRole = $el.val();
@@ -846,7 +852,8 @@ function onPromptInjectionChange() {
             settings.notebookPromptPosition = $el.val();
             $('#tv_notebook_depth_row').toggle($el.val() === 'in_chat');
         } else if (field === 'depth') {
-            settings.notebookPromptDepth = Math.max(1, Math.round(Number($el.val()) || 1));
+            const rawDepth = Number($el.val());
+            settings.notebookPromptDepth = Math.max(0, Math.round(Number.isFinite(rawDepth) ? rawDepth : 1));
             $el.val(settings.notebookPromptDepth);
         } else if (field === 'role') {
             settings.notebookPromptRole = $el.val();
@@ -1026,6 +1033,11 @@ function onSidecarAutoRetrievalToggle() {
     const settings = getSettings();
     settings.sidecarAutoRetrieval = $(this).prop('checked');
     $('#tv_sidecar_retrieval_fields').toggle(settings.sidecarAutoRetrieval);
+    if (!settings.sidecarAutoRetrieval) {
+        // Don't leave a previously injected retrieval prompt stuck in context
+        // now that the feature has been turned off.
+        clearRetrievalPrompt(settings);
+    }
     saveSettingsDebounced();
 }
 
@@ -1146,7 +1158,7 @@ async function onOpenTreeEditor() {
     if (bookData?.entries) {
         await syncTrackerUidsForLorebook(currentLorebook, bookData.entries);
     }
-    const entryLookup = buildEntryLookup(bookData);
+    let entryLookup = buildEntryLookup(bookData);
     const bookName = currentLorebook;
 
     // State: which node is selected in the tree

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -13,9 +13,13 @@ export default defineConfig({
             { find: '../../../st-context.js', replacement: resolve(__dirname, 'tests/__mocks__/st-context.js') },
             { find: '../../../../st-context.js', replacement: resolve(__dirname, 'tests/__mocks__/st-context.js') },
             { find: '../../../world-info.js', replacement: resolve(__dirname, 'tests/__mocks__/st-world-info.js') },
+            { find: '../../../../world-info.js', replacement: resolve(__dirname, 'tests/__mocks__/st-world-info.js') },
             { find: '../../../tool-calling.js', replacement: resolve(__dirname, 'tests/__mocks__/st-tool-calling.js') },
             { find: '../../../utils.js', replacement: resolve(__dirname, 'tests/__mocks__/st-utils.js') },
             { find: '../../../popup.js', replacement: resolve(__dirname, 'tests/__mocks__/st-popup.js') },
+            { find: '../../../group-chats.js', replacement: resolve(__dirname, 'tests/__mocks__/st-group-chats.js') },
+            { find: '../../../../chats.js', replacement: resolve(__dirname, 'tests/__mocks__/st-chats.js') },
+            { find: '../../../power-user.js', replacement: resolve(__dirname, 'tests/__mocks__/st-power-user.js') },
         ],
     },
     test: {


### PR DESCRIPTION
Hi! This is the second of two TunnelVision PRs from a compatibility pass against **SillyTavern staging (1.18.0, `380e31e`)**.

**Please merge #35 first** — this branch is stacked on it, so until that one lands GitHub will show both sets of changes here. Once it's merged this diff reduces to just the settings exposure described below.

Unlike the bugfix PR, this one is a judgement call rather than a defect fix, so I'd completely understand if you'd rather wire these up differently or not at all — happy to adjust or close it.

---

## Background

`world-state.js`, `smart-context.js`, and `memory-lifecycle.js` are complete, working subsystems — fully implemented, reading their configuration via `getSettings()` like every other module in the extension. But:

1. Their settings keys (`worldStateEnabled`, `smartContextEnabled`, `lifecycleEnabled`, and the associated tuning fields) were **never added to `SETTING_DEFAULTS`** in `tree-store.js`, so `getSettings()` never backfilled them.
2. `settings.html` had **no UI controls** for any of them — no checkbox, no fields, nothing a user could click.
3. `index.js` **never called** `initWorldState()`, `initSmartContext()`, or `initMemoryLifecycle()` during `init()` — only `initPostTurnProcessor()` was wired up, even though the post-turn processor's own settings (`postTurnEnabled` etc.) were already exposed.

The net effect: three fully-built features were permanently unreachable. There was no code path — not even a manual settings-file edit — by which a user could ever turn them on, because the enabling flags didn't exist anywhere in the defaults object the UI and the modules both read from.

This PR closes that gap for all three subsystems, and also finishes exposing the Post-Turn Processor's UI (which already had working settings keys but no settings-panel section).

## What's included

- **`tree-store.js`**: `SETTING_DEFAULTS` gains:
  - `worldStateEnabled`, `worldStateInterval`, `worldStateDepth`, `worldStateMaxChars`, `worldStatePosition`, `worldStateRole`, `worldStateInjectionOverride`, `worldStateUpdateOverride`
  - `smartContextEnabled`, `smartContextDepth`, `smartContextLookback`, `smartContextMaxChars`, `smartContextMaxEntries`, `smartContextPosition`, `smartContextRole`
  - `lifecycleEnabled`, `lifecycleInterval`, `lifecycleCompress`, `lifecycleConsolidate`, `lifecycleReorganize`
  - `totalInjectionBudget` (combined char cap across mandatory/world-state/smart-context/notebook prompt injections; `0` = unlimited)
  - `llmCallTimeout` (per-call timeout in ms for background LLM calls — tree building, world state, smart context, lifecycle, post-turn)

- **`settings.html`**: four new collapsible `.tv-card` sections — **Rolling World State**, **Smart Context**, **Memory Lifecycle**, **Post-Turn Processor** — each with its enable toggle and tuning fields, plus a **Total Injection Budget** field (under Prompt Injection settings) and a **Background LLM Call Timeout** field (under Advanced Settings).

- **`ui-controller.js`**: event bindings for every new control (collapsible headers, toggles, number inputs, injection-placement selects, override textareas + reset buttons) and the matching `refreshUI()` population logic that syncs the UI from `getSettings()` on load/change.

- **`index.js`**: calls `initWorldState()`, `initSmartContext()`, and `initMemoryLifecycle()` from `init()`, right alongside the existing `initPostTurnProcessor()` call.

## Behavior guarantees

- **Every `*Enabled` flag defaults to `false`.** This PR is purely additive — no existing install's runtime behavior changes on upgrade. A user has to explicitly open the settings panel and flip a toggle for any of this to do anything.
- **Every non-boolean default was taken from the inline `||`/`??` fallback already used at that setting's consumption site**, so nothing new is being invented. For example `world-state.js:366` already read `settings.worldStateInterval || 10` and `smart-context.js:1366` already read `settings.smartContextLookback || 6` — the `10` and `6` now in `SETTING_DEFAULTS` are exactly those values. Turning a feature on for the first time therefore behaves identically to what each module already assumed internally; the change just makes the values discoverable and editable instead of hard-coded at the read site.
- No existing settings keys were modified, renamed, or had their defaults changed.

## Scope boundary vs. the stacked fix PR

This branch is stacked on `fix/staging-compat-bugfixes`. A few files touched by both PRs had their changes split at the hunk level so each PR is reviewable independently:
- `tree-store.js`: this PR is *only* the new `SETTING_DEFAULTS` keys listed above (the `SUMMARY_TITLE_PREFIX` regex fix is on the fix PR).
- `ui-controller.js`: this PR is *only* the bindings/`refreshUI()` population for the new controls (the `entryLookup` `const→let` fix, the prompt-depth `Math.max(0,...)` fix, and the clear-retrieval-on-disable wiring are on the fix PR).
- `index.js`: this PR is *only* the three `init*()` calls and their imports (everything else — swipe detection, snapshot/DOM cleanup, re-entrancy guards, etc. — is on the fix PR).
- `settings.html` is entirely this PR (no bugfixes touch it).

## Verification

- `git diff origin/main feat/expose-worldstate-smartcontext-lifecycle-settings` reconstructs byte-identical to the original combined working-tree diff that included both this feature and all the staged bugfixes — confirmed via direct diff comparison against the pre-split baseline, so no content was lost or altered in the split.
- `npx vitest run` on this branch: **91 failed / 420 passed** (511 total) — identical to the pre-existing baseline on `main`. This PR does not touch any test file.
- `node --check` passed on every edited `.js` file (`index.js`, `tree-store.js`, `ui-controller.js`).

### Note on the 91 pre-existing test failures
Unrelated to this PR: they're pre-existing failures against a module decomposition (e.g. `pinSummaryEntries` expected as a standalone exported function from `tree-builder.js`) that never actually landed in the current codebase. Same count before and after this branch — this PR does not attempt to address them.
