### PR TITLE
fix(sidecar): allow an empty API key for local endpoints

### DIFF
--- a/llm-sidecar.js
+++ b/llm-sidecar.js
@@ -66,7 +66,9 @@ export function isCircuitOpen() {
 // ─── Config Resolution ──────────────────────────────────────────────
 
 /**
- * Resolve the sidecar generation config from settings.
+ * Resolve the sidecar generation config from settings. apiKey may be empty
+ * (local endpoints such as llama.cpp, KoboldCpp, Ollama and LM Studio serve
+ * an OpenAI-compatible API with no auth), so only the endpoint is required.
  * @returns {{endpoint:string, apiKey:string, model:string, format:string, maxTokens:number, temperature:number}|null}
  */
 export function getSidecarConfig() {
@@ -75,7 +77,7 @@ export function getSidecarConfig() {
     if (!p.enabled) return null;
     const endpoint = String(p.endpoint || '').trim();
     const apiKey = String(p.apiKey || '').trim();
-    if (!endpoint || !apiKey) return null;
+    if (!endpoint) return null;
     return {
         endpoint,
         apiKey,
@@ -197,7 +199,11 @@ export async function sidecarGenerate({ prompt, systemPrompt }) {
 
 async function _callOpenAI({ endpoint, apiKey, model, systemPrompt, prompt, temperature, maxTokens }) {
     const url = _normalizeChatEndpoint(endpoint);
-    const headers = { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` };
+    const headers = { 'Content-Type': 'application/json' };
+    // Omitted rather than sent empty: `Bearer ` with no credential is malformed,
+    // and a gateway in front of a local server may reject it on that basis.
+    // Matches _embedOpenAI, which already sets the header conditionally.
+    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
     if (/openrouter\.ai/i.test(url)) {
         headers['HTTP-Referer'] = (typeof window !== 'undefined' && window.location?.origin) || 'https://sillytavern.app';
         headers['X-Title'] = 'TunnelVision';

--- a/tests/llm-sidecar.test.js
+++ b/tests/llm-sidecar.test.js
@@ -73,9 +73,12 @@ describe('getSidecarConfig', () => {
         expect(getSidecarConfig()).toBeNull();
     });
 
-    it('returns null when apiKey is empty', () => {
-        mockSidecarProfile = { enabled: true, endpoint: 'https://example.com', apiKey: '', model: '', format: 'openai' };
-        expect(getSidecarConfig()).toBeNull();
+    it('returns a config when apiKey is empty (local endpoints need no auth)', () => {
+        mockSidecarProfile = { enabled: true, endpoint: 'http://127.0.0.1:5001/v1', apiKey: '', model: '', format: 'openai' };
+        const config = getSidecarConfig();
+        expect(config).not.toBeNull();
+        expect(config.endpoint).toBe('http://127.0.0.1:5001/v1');
+        expect(config.apiKey).toBe('');
     });
 
     it('returns structured config for valid profile', () => {
@@ -148,9 +151,9 @@ describe('isSidecarConfigured', () => {
         expect(isSidecarConfigured()).toBe(false);
     });
 
-    it('returns false when apiKey is missing', () => {
-        mockSidecarProfile = { enabled: true, endpoint: 'https://example.com' };
-        expect(isSidecarConfigured()).toBe(false);
+    it('returns true when apiKey is missing (local endpoints need no auth)', () => {
+        mockSidecarProfile = { enabled: true, endpoint: 'http://127.0.0.1:5001/v1' };
+        expect(isSidecarConfigured()).toBe(true);
     });
 
     it('returns false when not enabled', () => {
@@ -235,6 +238,23 @@ describe('sidecarGenerate', () => {
         const body = JSON.parse(opts.body);
         expect(body.model).toBe('gpt-4o-mini');
         expect(body.messages).toEqual([{ role: 'user', content: 'hello' }]);
+
+        vi.unstubAllGlobals();
+    });
+
+    it('omits the Authorization header when apiKey is empty', async () => {
+        mockSidecarProfile = { ...validProfile, apiKey: '' };
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ choices: [{ message: { content: 'ok' } }] }),
+        });
+        vi.stubGlobal('fetch', mockFetch);
+
+        await sidecarGenerate({ prompt: 'hello' });
+
+        const [, opts] = mockFetch.mock.calls[0];
+        expect(opts.headers).not.toHaveProperty('Authorization');
+        expect(opts.headers['Content-Type']).toBe('application/json');
 
         vi.unstubAllGlobals();
     });


### PR DESCRIPTION
Fixes #34.

### The problem

`getSidecarConfig()` treated the API key as mandatory:

```js
if (!endpoint || !apiKey) return null;
```

A sidecar pointed at a local server has no key to give, so the config resolved to `null` and every caller quietly treated the sidecar as unconfigured. "Test Connection" reported **"No sidecar configuration to test."** (`llm-sidecar.js:299`) and no request ever left SillyTavern.

The giveaway from the issue: typing an arbitrary junk string into the key field makes everything work. The value was never used for authentication — only its presence was being checked.

This matters because the local, unauthenticated case is a normal deployment rather than an edge case: llama.cpp's `llama-server`, KoboldCpp, Ollama and LM Studio all serve an OpenAI-compatible API with no auth by default.

### Prior art in this file

`getEmbeddingConfig()`, ~30 lines below, already handles it the right way — it requires only the endpoint, and its docstring says *"apiKey may be empty (local endpoints)"*. `_embedOpenAI()` likewise sets `Authorization` only when a key is present. This PR brings the sidecar path in line with the embedding path rather than inventing a new convention.

### Changes

- **`getSidecarConfig()`** requires only `endpoint`. `apiKey` is still trimmed and returned, so remote profiles are completely unaffected.
- **`_callOpenAI()`** omits the `Authorization` header when the key is empty rather than sending a bare `Bearer `, matching `_embedOpenAI()`.

To be clear about that second one: it is consistency rather than a second bug fix. I checked, and `llama-server` accepts both a missing header and a bare `Bearer ` — so it is not what was breaking the issue. The reasoning for it is that a credential-less `Bearer ` is malformed, and a gateway sitting in front of a local server could reasonably reject it. Happy to drop it if you would rather keep the diff to the one-line gate.

`_callAnthropic()` and `_callGoogle()` are deliberately untouched — both target services where a key is genuinely required.

### Tests

Two existing tests asserted the old contract and are updated:

- `getSidecarConfig > returns null when apiKey is empty` → now expects a resolved config
- `isSidecarConfigured > returns false when apiKey is missing` → now expects `true`

One test is added: `omits the Authorization header when apiKey is empty`.

`tests/llm-sidecar.test.js` is **62/62 passing**.

⚠️ The full suite is already failing on `main` before this change — **109 failed / 394 passed**. With this change it is **109 failed / 395 passed**: the same set of failures, plus the one added test. Nothing here touches those pre-existing failures, but you may want to know they are there.

### Verification

`llama-server` was confirmed to answer `POST /v1/chat/completions` with no `Authorization` header at all (HTTP 200), which is the configuration the issue describes and the one the old gate made unreachable.
