### PR TITLE
fix: honour the static-entry guard on lifecycle and post-turn writes

### DIFF
--- a/memory-lifecycle.js
+++ b/memory-lifecycle.js
@@ -596,7 +596,7 @@ async function findAndMergeDuplicates(bookName, bookData, chatId) {
           await updateEntry(bookName, keepUid, {
             content: pair.merged_content,
             ...(pair.merged_title ? { comment: pair.merged_title } : {}),
-            _source: "lifecycle",
+            _backgroundSource: "lifecycle",
           });
         }
 

--- a/post-turn-processor.js
+++ b/post-turn-processor.js
@@ -1083,7 +1083,7 @@ export async function updateTrackers(trackers, recentExcerpt, chatId) {
         const previousContent = tracker.content;
         await updateEntry(tracker.book, Number(update.uid), {
           content: newContent,
-          _source: "post-turn",
+          _backgroundSource: "post-turn",
         });
 
         setTrackerHash(tracker.book, tracker.uid, contentHash(newContent));

--- a/tests/post-turn-processor.test.js
+++ b/tests/post-turn-processor.test.js
@@ -261,7 +261,9 @@ describe('updateTrackers', () => {
         ]);
         expect(updateEntry).toHaveBeenCalledWith('test-book', 7, {
             content: '## Current Status\nMood: alert',
-            _source: 'post-turn',
+            // Must be _backgroundSource: updateEntry reads that key to run the
+            // static-entry guard. Any other spelling silently disables it.
+            _backgroundSource: 'post-turn',
         });
         expect(getContext().chatMetadata.tunnelvision_tracker_hashes['test-book:7'].hash)
             .toBe(contentHash('## Current Status\nMood: alert'));
@@ -297,7 +299,7 @@ describe('updateTrackers', () => {
         expect(result.updated).toBe(1);
         expect(updateEntry).toHaveBeenCalledWith('test-book', 9, {
             content: '## Current Status\nLocation: safehouse',
-            _source: 'post-turn',
+            _backgroundSource: 'post-turn',
         });
     });
 });


### PR DESCRIPTION
`updateEntry` runs `assertBackgroundEntryMutable(entry, updates._backgroundSource)` (`entry-manager.js:195`), but two callers passed the key as `_source`. The guard received `undefined` and did not fire, so a `constant: true` entry could be rewritten by background automation on those paths.

This reads as a slip rather than intent — `memory-lifecycle.js` passes the correct key at `:561`, `:604` and `:758`, including the `forgetEntry` call three lines below the one fixed here.

The existing tracker tests asserted `_source: 'post-turn'`, which pinned the typo in place; updating those assertions is the regression coverage. Verified both directions: **2 failed** against the unfixed source, **4 passed** with the fix.

Note `updateEntry` only applies `content`/`comment`/`keys`, so the stray key was never written into the entry — the sole effect was the bypassed guard.

Both affected paths are behind settings that default off, so the practical blast radius is small today. Raising it because a silently-absent guard reads as protection in code review.

Heads-up unrelated to this change: `npm test` on `main` @ `58847fd` currently reports **91 failed / 421 passed**. This PR leaves that count unchanged — happy to look at those separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
