### PR TITLE
fix: define <who> in the SECRET tag so the right character is named

### DIFF
--- a/shared-utils.js
+++ b/shared-utils.js
@@ -290,12 +290,18 @@ export const SECRET_TAG_RE = /\[SECRET\b/i;
 export const SECRET_GUARD_LINE =
     '[Roleplay guidance: some retrieved entries use [SECRET …] for information a character does not yet know. ' +
     'This tag does not hide content from the model or provide privacy/access control. ' +
-    'Treat them as narrator-only dramatic irony — do not let that character reveal, act on, or acknowledge the ' +
-    "information until the story establishes they've learned it.]";
+    'Treat them as narrator-only dramatic irony — do not let the character named in the tag reveal, act on, or ' +
+    "acknowledge the information until the story establishes they've learned it. Characters not named in the tag " +
+    'are unaffected and may know it.]';
 
 /** Appended to write-tool content descriptions so the model applies/removes the tag. */
 export const SECRET_AUTHORING_INSTRUCTION =
     ' For roleplay guidance only (not privacy or access control), if information is unknown to a character ' +
     '(secrets, dramatic irony, things not yet learned), ' +
-    'prefix the content with [SECRET — <who> is unaware]. When the story establishes the character has learned it, ' +
-    'update the entry to remove the tag.';
+    'prefix the content with [SECRET — <who> is unaware]. <who> is the character who does NOT know the ' +
+    'information — not the character the entry is about, unless they are the same person. ' +
+    "Example: Elena is secretly the heir and Marcus has not learned this, so the entry about Elena's " +
+    'heritage reads [SECRET — Marcus is unaware] Elena is the lost heir. ' +
+    'Tag only when the chat shows that character does not know it; never tag information a character already ' +
+    'has, and if in doubt omit the tag. ' +
+    'When the story establishes the character has learned it, update the entry to remove the tag.';

--- a/tests/shared-utils.test.js
+++ b/tests/shared-utils.test.js
@@ -502,7 +502,7 @@ import {
 
 describe('secret tag', () => {
     it('matches a tagged entry regardless of case and suffix', () => {
-        expect(SECRET_TAG_RE.test('[SECRET — Elena is unaware] She is the heir.')).toBe(true);
+        expect(SECRET_TAG_RE.test('[SECRET — Marcus is unaware] Elena is the heir.')).toBe(true);
         expect(SECRET_TAG_RE.test('[secret] hidden')).toBe(true);
         expect(SECRET_TAG_RE.test('[SECRET: king] plot')).toBe(true);
     });
@@ -517,5 +517,14 @@ describe('secret tag', () => {
         expect(SECRET_AUTHORING_INSTRUCTION).toContain('[SECRET');
         expect(SECRET_GUARD_LINE).toContain('does not hide content');
         expect(SECRET_AUTHORING_INSTRUCTION).toContain('not privacy or access control');
+    });
+
+    it('authoring instruction defines <who> as the character who does not know it', () => {
+        // Regression: the model filled <who> with the entry's subject, producing
+        // "[SECRET — B is unaware]" for a fact only A is ignorant of, and tagging
+        // facts a character already knows.
+        expect(SECRET_AUTHORING_INSTRUCTION).toContain('does NOT know');
+        expect(SECRET_AUTHORING_INSTRUCTION).toContain('not the character the entry is about');
+        expect(SECRET_AUTHORING_INSTRUCTION).toContain('[SECRET — Marcus is unaware]');
     });
 });

--- a/tests/smart-context.test.js
+++ b/tests/smart-context.test.js
@@ -783,7 +783,7 @@ describe('secret guard', () => {
                     uid: 10,
                     comment: 'Elena heritage',
                     key: ['elena'],
-                    content: '[SECRET — Elena is unaware] Elena is the lost heir.',
+                    content: '[SECRET — Marcus is unaware] Elena is the lost heir.',
                 }),
             },
         });

--- a/tool-registry.js
+++ b/tool-registry.js
@@ -639,7 +639,7 @@ function buildGuideDescription(allDefs, disabled) {
 - Use Forget only when information is definitively wrong or irrelevant
 - Use Summarize for significant scenes and narrative beats
 - Keep entries broad — combine related facts rather than creating many small entries
-- Use [SECRET — <who> is unaware] only as roleplay guidance for content a character must not know; it does not hide content from the model. Remove the tag via Update once the story establishes they've learned it`;
+- Use [SECRET — <who> is unaware] only as roleplay guidance for content a character must not know; <who> is the character who does NOT know it, not the entry's subject. It does not hide content from the model. Remove the tag via Update once the story establishes they've learned it`;
 
     // Add dynamic content (tree overview, tracker list) to the guide
     const treeOverview = getTreeOverview();

--- a/tree-builder.js
+++ b/tree-builder.js
@@ -1084,7 +1084,7 @@ Rules:
 - Skip trivial or generic information
 - Merge related facts into single entries when they belong together
 - If a subject already appears in the "Already in lorebook" list above, write content as an addendum — state only the new specific detail, do NOT restate who they are or repeat their general description
-- Tag a secret ONLY when the chat explicitly shows a character does not know a fact. This is roleplay guidance, not privacy or access control: injected content remains visible to the model. Prefix that entry's content with [SECRET — <who> is unaware]. Never infer or invent ignorance — if in doubt, omit the tag.
+- Tag a secret ONLY when the chat explicitly shows a character does not know a fact. This is roleplay guidance, not privacy or access control: injected content remains visible to the model. Prefix that entry's content with [SECRET — <who> is unaware], where <who> is the character who does NOT know the fact — not the character the entry is about, unless they are the same person (e.g. an entry about Elena's hidden heritage that Marcus has not learned reads [SECRET — Marcus is unaware]). Never infer or invent ignorance, and never tag a fact a character already knows — if in doubt, omit the tag.
 
 Chat log:
 ${chatText}


### PR DESCRIPTION
## Problem

The `[SECRET — <who> is unaware]` convention never defined `<who>`. No prompt said whose name belongs there, so models filled it with the **entry's subject** instead of the character who does not know:

- a fact only A was ignorant of came back as `[SECRET — B is unaware]`
- entries about A were tagged `[SECRET — A is unaware]` even when A already knew

Both symptoms come from the same gap. Nothing in the codebase parses the tag — `SECRET_TAG_RE` only tests for its presence — so the convention is model-authored end to end and the fix is prompt wording.

## Changes

- `shared-utils.js` — `SECRET_AUTHORING_INSTRUCTION` defines `<who>` as the character who does **not** know, states explicitly that it is not the character the entry is about, adds a worked example, and forbids tagging information a character already has.
- `shared-utils.js` — `SECRET_GUARD_LINE` says "the character named in the tag" instead of the ambiguous "that character", and notes unnamed characters are unaffected (the read side misfired the same way with several characters in scene).
- `tree-builder.js` (ingest prompt) and `tool-registry.js` (`buildGuideDescription`) carry their own hand-written copies of the convention; both get the same disambiguation.
- `tools/remember.js`, `tools/update.js`, `tools/merge-split.js` inherit the fix through the shared constant — untouched.

## Tests

- New assertion in `tests/shared-utils.test.js` that the authoring instruction defines `<who>`.
- Fixtures changed from `[SECRET — Elena is unaware] Elena is the lost heir` — which models the exact mistake — to `Marcus`.

Note: I could not run vitest in my checkout (the suite needs the SillyTavern parent modules, e.g. `../../../group-chats.js`, and 109/511 tests fail on unmodified `main` here for that reason). The changed constants were verified at string level. Please confirm the suite in a real ST tree.
