### PR TITLE
fix(remember): dedup on meaning, not character overlap

### DIFF
--- a/embedding-cache.js
+++ b/embedding-cache.js
@@ -248,6 +248,62 @@ async function ensureEmbeddings(candidates) {
 // ── Similarity Scoring ───────────────────────────────────────────
 
 /**
+ * Find candidates whose embedding cosine against `text` meets `threshold`.
+ *
+ * Shares the entry cache with the smart-context pipeline, so callers pay for one
+ * embedding of `text` rather than re-embedding the book. Used by
+ * TunnelVision_Remember to catch reworded duplicates that character-trigram
+ * overlap cannot see.
+ *
+ * @param {Array<{entry: Object, bookName: string}>} candidates
+ * @param {string} text - The new text to compare against
+ * @param {number} threshold - 0-1 cosine threshold
+ * @param {number} [limit=3] - Maximum matches to return, highest first
+ * @returns {Promise<Array<{uid: number, comment: string, similarity: number}>>}
+ */
+export async function findSimilarByEmbedding(candidates, text, threshold, limit = 3) {
+  if (!candidates?.length || !text) return [];
+
+  await ensureEmbeddings(candidates);
+
+  let queryEmbedding;
+  try {
+    const embeddings = await computeEmbeddings([
+      text.substring(0, EMBEDDING_MAX_TEXT_LENGTH),
+    ]);
+    queryEmbedding = embeddings?.[0];
+  } catch (e) {
+    console.debug("[TunnelVision] Similarity query embedding failed:", e.message);
+    return [];
+  }
+  if (!queryEmbedding) return [];
+
+  const matches = [];
+  for (const c of candidates) {
+    const content = (c.entry.content || "").trim();
+    const entryText = ((c.entry.comment || "") + " " + content).substring(
+      0, EMBEDDING_MAX_TEXT_LENGTH,
+    );
+    const entryEmbedding = getCachedEmbedding(
+      c.bookName, c.entry.uid, hashString(entryText),
+    );
+    if (!entryEmbedding) continue;
+
+    const similarity = cosineSimilarity(queryEmbedding, entryEmbedding);
+    if (similarity >= threshold) {
+      matches.push({
+        uid: c.entry.uid,
+        comment: c.entry.comment || `Entry #${c.entry.uid}`,
+        similarity: Math.round(similarity * 100),
+      });
+    }
+  }
+
+  matches.sort((a, b) => b.similarity - a.similarity);
+  return matches.slice(0, limit);
+}
+
+/**
  * Compute embedding similarity boosts for candidates against recent chat text.
  * Returns a Map of UID → bonus score (0–8 range).
  * @param {Array<{entry: Object, bookName: string, score: number}>} candidates

--- a/settings.html
+++ b/settings.html
@@ -541,12 +541,27 @@
                                 <span id="tv_dedup_method_text">Checking...</span>
                             </div>
                             <div class="tv-help-text" style="margin-top: 4px;">
-                                Uses trigram similarity — fast character n-gram matching that catches near-duplicates and morphological variants. No external dependencies needed.
+                                Uses <strong>embedding similarity</strong> when an Embedding Sidecar is configured — this catches duplicates that were reworded. Falls back to <strong>trigram</strong> (character n-gram) matching otherwise, which only catches near-identical text.
                             </div>
                             <div id="tv_dedup_threshold_row" class="tv-number-row" style="margin-top: 8px; display: none;">
-                                <label class="tv-number-label" for="tv_dedup_threshold">Similarity threshold:</label>
+                                <label class="tv-number-label" for="tv_dedup_threshold">Embedding threshold:</label>
                                 <input id="tv_dedup_threshold" type="number" class="tv-number-input" min="0.5" max="0.99" step="0.01" value="0.85" />
-                                <span class="tv-help-text" style="margin: 0;">(0.85 = high similarity)</span>
+                                <span class="tv-help-text" style="margin: 0;">(cosine — 0.85 = same meaning)</span>
+                            </div>
+                            <div id="tv_trigram_threshold_row" class="tv-number-row" style="margin-top: 8px; display: none;">
+                                <label class="tv-number-label" for="tv_trigram_threshold">Trigram threshold:</label>
+                                <input id="tv_trigram_threshold" type="number" class="tv-number-input" min="0.2" max="0.99" step="0.01" value="0.6" />
+                                <span class="tv-help-text" style="margin: 0;">(character overlap — 0.85 here means "nearly the same string", so it wants a lower value than the embedding threshold)</span>
+                            </div>
+                            <div id="tv_dedup_mode_row" style="margin-top: 10px; display: none;">
+                                <label class="tv-number-label" for="tv_remember_dedup_mode">On duplicate:</label>
+                                <select id="tv_remember_dedup_mode" class="tv-select" style="width: auto; margin-left: 6px;">
+                                    <option value="warn">Warn, save anyway</option>
+                                    <option value="redirect">Decline, tell the AI to update instead</option>
+                                </select>
+                                <div class="tv-help-text" style="margin-top: 4px;">
+                                    <strong>Warn</strong> is the original behaviour: the entry is always written and a note is appended afterwards — by which point the duplicate exists, so it is easily ignored. <strong>Decline</strong> refuses the write and returns the matching UIDs so the AI must call Update, with <code>force=true</code> available when the new information really is distinct.
+                                </div>
                             </div>
                         </div>
 

--- a/tools/remember.js
+++ b/tools/remember.js
@@ -3,17 +3,28 @@
  * Allows the model to create new lorebook entries mid-generation.
  * The entry is saved to the lorebook and automatically assigned to a tree node.
  *
- * Duplicate detection uses trigram similarity — fast character n-gram overlap
- * that catches morphological variants and near-duplicates without needing vectors.
+ * Duplicate detection prefers embedding cosine when an embedding profile is
+ * configured, since character overlap cannot see a duplicate that was reworded.
+ * It falls back to trigram similarity — fast character n-gram overlap that
+ * catches morphological variants — when no embedding endpoint is available, or
+ * if embedding fails.
+ *
+ * Each metric has its own threshold: `vectorDedupThreshold` (cosine, default
+ * 0.85) and `trigramDedupThreshold` (Jaccard, default 0.6). They are not
+ * interchangeable — 0.85 cosine means "these mean the same thing", while 0.85
+ * trigram means "these are nearly the same string".
+ *
  * The warning is non-blocking: the entry is always saved regardless of duplicates found.
  */
 
 import { loadWorldInfo } from '../../../../world-info.js';
 import { getSettings } from '../tree-store.js';
+import { isEmbeddingAvailable, findSimilarByEmbedding } from '../embedding-cache.js';
 import { createEntry } from '../entry-manager.js';
 import { getWritableBooks, resolveTargetBook, getBookListWithDescriptions } from '../tool-registry.js';
 import { getLanguageInstruction } from '../agent-utils.js';
 import { SECRET_AUTHORING_INSTRUCTION } from '../shared-utils.js';
+import { TOOL_NAME as UPDATE_TOOL_NAME } from './update.js';
 
 export const TOOL_NAME = 'TunnelVision_Remember';
 export const COMPACT_DESCRIPTION = 'Save a new fact, character detail, relationship, or world-building info to long-term memory.';
@@ -57,6 +68,34 @@ function trigramSimilarity(a, b) {
 }
 
 // ─── Dedup ──────────────────────────────────────────────────────
+
+/**
+ * Find similar entries by embedding cosine — catches reworded duplicates that
+ * character-trigram overlap cannot ("Keppler's Drift" vs "Keppler's Drift as a
+ * Potential Destination" share little literal text but describe one subject).
+ *
+ * Delegates to embedding-cache.js so entry vectors are shared with the smart
+ * context pipeline: same two-tier cache, same content-hash invalidation, so a
+ * Remember call costs one embedding for the new text rather than re-embedding
+ * the whole book.
+ * @param {string} bookName
+ * @param {string} newContent
+ * @param {string} newTitle
+ * @param {number} threshold - 0-1 cosine threshold
+ * @returns {Promise<Array<{uid: number, comment: string, similarity: number}>>}
+ */
+async function findSimilarEntriesSemantic(bookName, newContent, newTitle, threshold) {
+    const bookData = await loadWorldInfo(bookName);
+    if (!bookData?.entries) return [];
+
+    const candidates = Object.keys(bookData.entries)
+        .map(key => bookData.entries[key])
+        .filter(entry => !entry.disable && (entry.content || entry.comment))
+        .map(entry => ({ entry, bookName }));
+    if (candidates.length === 0) return [];
+
+    return findSimilarByEmbedding(candidates, `${newTitle} ${newContent}`, threshold);
+}
 
 /**
  * Find similar entries in a lorebook using trigram similarity.
@@ -137,6 +176,10 @@ Save entries to the lorebook where they belong based on the descriptions above. 
                     type: 'string',
                     description: 'Optional tree node ID to file this entry under. Omit to place at the root level.',
                 },
+                force: {
+                    type: 'boolean',
+                    description: 'Save even if this closely matches an existing entry. Only set this after being shown near-duplicates and deciding the new information is genuinely distinct — otherwise prefer updating the existing entry.',
+                },
             },
             required: ['lorebook', 'title', 'content'],
         },
@@ -148,20 +191,55 @@ Save entries to the lorebook where they belong based on the descriptions above. 
             const { book: lorebook, error } = resolveTargetBook(args.lorebook, { checkWrite: true });
             if (error) return error;
 
-            // Dedup check (non-blocking — warns but still saves)
+            // Dedup check (non-blocking — warns but still saves).
+            //
+            // Two metrics, two thresholds. `vectorDedupThreshold` (0.85) is a
+            // COSINE threshold: as trigram-Jaccard it means "nearly the same
+            // string", which reworded duplicates never reach — so applying it to
+            // the trigram path made the check silently inert. Use embeddings when
+            // an embedding profile is configured; fall back to trigram at its own,
+            // looser default otherwise.
             let dedupWarning = '';
             const settings = getSettings();
             if (settings.enableVectorDedup) {
-                const threshold = settings.vectorDedupThreshold || 0.85;
-                const matches = await findSimilarEntries(
-                    lorebook, args.content, args.title, threshold,
-                );
+                let matches = [];
+                let metric = 'trigram';
+                if (isEmbeddingAvailable()) {
+                    const threshold = settings.vectorDedupThreshold || 0.85;
+                    try {
+                        matches = await findSimilarEntriesSemantic(
+                            lorebook, args.content, args.title, threshold,
+                        );
+                        metric = 'embedding';
+                    } catch (e) {
+                        // A dedup failure must never cost the caller their memory.
+                        console.warn('[TunnelVision] Embedding dedup failed, falling back to trigram:', e);
+                    }
+                }
+                if (metric === 'trigram') {
+                    const threshold = settings.trigramDedupThreshold || 0.6;
+                    matches = await findSimilarEntries(
+                        lorebook, args.content, args.title, threshold,
+                    );
+                }
                 if (matches.length > 0) {
                     const lines = matches.map(
                         m => `  - "${m.comment}" (UID ${m.uid}, ${m.similarity}% match)`,
                     );
+                    console.log(`[TunnelVision] Dedup (${metric}): ${matches.length} similar entries for "${args.title}"`);
+
+                    // 'redirect' declines the write and hands back the UIDs, so the
+                    // model has to choose Update. Advisory text appended AFTER a
+                    // successful save is ignored in practice — the entry already
+                    // exists by the time the model reads it, and nothing makes it
+                    // go back. `force` is the escape hatch for a genuine near-miss.
+                    const mode = settings.rememberDedupMode || 'warn';
+                    if (mode === 'redirect' && !args.force) {
+                        return `Not saved — "${args.title}" closely matches existing entries:\n${lines.join('\n')}\n`
+                            + `Use ${UPDATE_TOOL_NAME} with the correct UID to revise or extend one of them. `
+                            + `If this really is distinct information, call this tool again with force=true.`;
+                    }
                     dedupWarning = `\n⚠ Similar entries found:\n${lines.join('\n')}\nConsider using the Update tool instead if this is the same information.`;
-                    console.log(`[TunnelVision] Dedup: ${matches.length} similar entries for "${args.title}"`);
                 }
             }
 

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -36,6 +36,7 @@ import {
 } from './tree-store.js';
 import { buildTreeFromMetadata, buildTreeWithLLM, generateSummariesForTree, ingestChatMessages } from './tree-builder.js';
 import { testSidecarConnectivity, testEmbeddingConnectivity } from './llm-sidecar.js';
+import { isEmbeddingAvailable } from './embedding-cache.js';
 import { registerTools, unregisterTools, getDefaultToolDescriptions, stripDynamicContent } from './tool-registry.js';
 import { runDiagnostics } from './diagnostics.js';
 import { clearRetrievalPrompt } from './sidecar-retrieval.js';
@@ -156,6 +157,8 @@ export function bindUIEvents() {
     // Vector dedup toggle + threshold
     $('#tv_vector_dedup').on('change', onVectorDedupToggle);
     $('#tv_dedup_threshold').on('change', onDedupThresholdChange);
+    $('#tv_trigram_threshold').on('change', onTrigramThresholdChange);
+    $('#tv_remember_dedup_mode').on('change', onRememberDedupModeChange);
 
     // Chat ingest
     $('#tv_ingest_chat').on('click', onIngestChat);
@@ -370,6 +373,10 @@ export function refreshUI() {
     $('#tv_vector_dedup').prop('checked', dedupEnabled);
     $('#tv_dedup_threshold_row').toggle(dedupEnabled);
     $('#tv_dedup_threshold').val(settings.vectorDedupThreshold ?? 0.85);
+    $('#tv_trigram_threshold_row').toggle(dedupEnabled);
+    $('#tv_trigram_threshold').val(settings.trigramDedupThreshold ?? 0.6);
+    $('#tv_dedup_mode_row').toggle(dedupEnabled);
+    $('#tv_remember_dedup_mode').val(settings.rememberDedupMode || 'warn');
     updateDedupStatus(dedupEnabled);
 
     // Sync mandatory tool calls & prompt injection
@@ -776,6 +783,8 @@ function onVectorDedupToggle() {
     settings.enableVectorDedup = enabled;
     saveSettingsDebounced();
     $('#tv_dedup_threshold_row').toggle(enabled);
+    $('#tv_trigram_threshold_row').toggle(enabled);
+    $('#tv_dedup_mode_row').toggle(enabled);
     updateDedupStatus(enabled);
 }
 
@@ -786,6 +795,25 @@ function onDedupThresholdChange() {
 
     const settings = getSettings();
     settings.vectorDedupThreshold = clamped;
+    saveSettingsDebounced();
+}
+
+function onTrigramThresholdChange() {
+    // Deliberately allows lower values than the cosine threshold: trigram overlap
+    // at 0.85 means "nearly the same string", which reworded duplicates never reach.
+    const raw = Number($('#tv_trigram_threshold').val());
+    const clamped = Math.min(Math.max(raw, 0.2), 0.99);
+    $('#tv_trigram_threshold').val(clamped);
+
+    const settings = getSettings();
+    settings.trigramDedupThreshold = clamped;
+    saveSettingsDebounced();
+}
+
+function onRememberDedupModeChange() {
+    const mode = $('#tv_remember_dedup_mode').val() === 'redirect' ? 'redirect' : 'warn';
+    const settings = getSettings();
+    settings.rememberDedupMode = mode;
     saveSettingsDebounced();
 }
 
@@ -801,7 +829,11 @@ function updateDedupStatus(enabled) {
         return;
     }
     $status.show();
-    $text.text('Using trigram similarity — fast character n-gram matching that catches near-duplicates and morphological variants.');
+    // Name the metric actually in use — the two behave very differently, and a
+    // reworded duplicate only gets caught on the embedding path.
+    $text.text(isEmbeddingAvailable()
+        ? 'Using embedding similarity via the Embedding Sidecar — catches reworded duplicates.'
+        : 'Using trigram similarity — character n-gram matching. Catches near-identical text only; configure an Embedding Sidecar to catch reworded duplicates.');
 }
 
 // ─── Tree Building ───────────────────────────────────────────────


### PR DESCRIPTION
Duplicate detection was gated on `enableVectorDedup` and used `vectorDedupThreshold`
(0.85), but the comparison it actually ran was `trigramSimilarity()` — character n-gram
overlap, not vectors.

0.85 is a sensible *cosine* threshold, meaning "these mean the same thing". As a *trigram
Jaccard* threshold it means "these are nearly the same string", which two entries about
one subject written in different words never reach. So the check ran on every save and
found nothing.

Separately, when it did fire, the warning was appended to the success string *after*
`createEntry` had run — so the model was told "saved, consider using Update instead" at a
point where the duplicate already existed and nothing would send it back.

What that looks like in use: one book here grew from 16 to 31 entries in a single
session, including three character-identical titles created in one turn.

## Changes

- **Prefer embedding cosine when an Embedding Sidecar is configured**, delegating to
  `embedding-cache.js` so entry vectors are shared with the smart-context pipeline — same
  two-tier cache, content-hash invalidation, batching and truncation. A Remember call then
  costs one embedding for the new text rather than re-embedding the book.
- **Fall back to trigram** when no embedding endpoint is configured, or if embedding
  throws: a dedup failure must never cost the caller their memory.
- **Split the thresholds.** `vectorDedupThreshold` stays cosine (0.85); new
  `trigramDedupThreshold` defaults to 0.6.
- **New `rememberDedupMode`:** `warn` (default, behaviour unchanged) or `redirect`, which
  declines the write and returns the matching UIDs so the model has to call Update with a
  real target. New `force` parameter as the escape hatch when the information really is
  distinct.
- **Settings UI** for both thresholds and the mode. The status line now names the metric
  actually in use, because only the embedding path catches a reworded duplicate and that
  distinction was invisible.

Default stays `warn`, so existing installs are unaffected until someone changes it.

## Exercised in live play

Run in a dedicated test chat, chat model `gemma-4-26B` via llama.cpp with ST function
calling on, embeddings `qwen/qwen3-embedding-8b`, single writable lorebook.

- ✅ **Detection fires on a reworded duplicate — 93%.** Baseline entry *"The Moxie's
  portside thruster number three was damaged by shrapnel. The coolant line cracked and the
  engine is running at 30% capacity."*; the model then stored *"The Moxie's third port-side
  engine thruster sustained shrapnel damage. A split coolant pipe has reduced the drive's
  output to roughly thirty percent power."* Result: `⚠ Similar entries found: "Engine
  damage report" (UID 0, 93% match)`.
- ✅ **And the metric really is cosine, measured rather than assumed.** `trigramSimilarity()`
  on that exact pair returns **0.301**. So under the old code — trigram compared against
  the 0.85 `vectorDedupThreshold` — detection was not merely unlikely, it was arithmetically
  impossible. 0.301 is below even the new 0.6 trigram threshold.
- ✅ **`warn`** wrote the entry (UID 1) and appended the similar-entry list.
- ✅ **`redirect` declines and creates nothing.** `Not saved — … closely matches existing
  entries: "Moxie Engine Damage Report" (UID 1, 94% match), "Engine damage report" (UID 0,
  93% match). Use TunnelVision_Update with the correct UID … If this really is distinct
  information, call this tool again with force=true.` Book UIDs unchanged across the call.
  Also observed model-driven, not just by direct invocation: three matches returned
  (95/94/92%), no entry created.
- ✅ **`force: true`** wrote the entry despite the duplicates, still reporting them.

## The one thing still unobserved, stated plainly

**A decline followed by the model recovering in the same turn.** It never arose naturally,
because whenever `TunnelVision_Update` was available the model **chose Update by itself** —
twice, both times against the correct UID — so it never reached `Remember` to be declined.
When I explicitly instructed it to use `Remember` and not `Update`, it accepted the decline
and continued the scene without retrying.

**No content was lost in any run** (every declined write was a genuine duplicate). But the
recovery-after-decline path is untested, so if you would rather ship only the cosine/trigram
fix and hold `rememberDedupMode` back for a separate PR, say so and I will split it. Default
stays `warn` either way.