### PR TITLE
fix(summary): make auto-summary work, and make the chat show what the model sees

### DIFF
--- a/auto-summary.js
+++ b/auto-summary.js
@@ -9,6 +9,7 @@ import { eventSource, event_types, setExtensionPrompt, extension_prompt_types } 
 import { getContext } from '../../../st-context.js';
 import { getSettings } from './tree-store.js';
 import { getActiveTunnelVisionBooks } from './tool-registry.js';
+import { runSummary } from './summary-runner.js';
 
 const TV_AUTOSUMMARY_KEY = 'tunnelvision_autosummary';
 const TV_AUTOSUMMARY_COUNTER_KEY = 'tunnelvision_autosummary_counter';
@@ -27,9 +28,10 @@ export function initAutoSummary() {
     // may not fire again for a chat that was loaded before this ran).
     hydrateCounterFromMetadata();
 
-    // Count user+AI messages
+    // Count user+AI messages. Only the AI-reply event may TRIGGER a run — firing
+    // on MESSAGE_SENT would summarize a turn that has not been answered yet.
     if (event_types.MESSAGE_RECEIVED) {
-        eventSource.on(event_types.MESSAGE_RECEIVED, onMessageReceived);
+        eventSource.on(event_types.MESSAGE_RECEIVED, onMessageReceivedAndMaybeRun);
     }
     // Also count user messages sent
     if (event_types.MESSAGE_SENT) {
@@ -65,44 +67,64 @@ function onMessageReceived() {
     persistCounter(chatId, count);
 }
 
+/**
+ * ⚠️ This used to inject an [AUTO-SUMMARY INSTRUCTION] telling the CHAT model it
+ * MUST call TunnelVision_Summarize. That only ever worked when the host had
+ * function calling enabled; with it off (a supported, commonly recommended
+ * configuration) the request carries no tools array, the model cannot comply,
+ * and it types the tool call into the scene as narrative text instead.
+ *
+ * Auto-summary now performs the summary itself via the analytical connection
+ * (see summary-runner.js), so it no longer depends on host tool support at all.
+ * This handler survives only to purge any stale injected prompt.
+ */
 function onGenerationForAutoSummary() {
+    clearPrompt();
+}
+
+/** True while a summary is in flight, so overlapping turns cannot double-fire. */
+let _summaryInFlight = false;
+
+/** Count the AI reply, then run a summary if the interval has been reached. */
+async function onMessageReceivedAndMaybeRun() {
+    onMessageReceived();
+    await maybeRunAutoSummary();
+}
+
+async function maybeRunAutoSummary() {
     const settings = getSettings();
-    if (!settings.autoSummaryEnabled || settings.globalEnabled === false) {
-        clearPrompt();
-        return;
-    }
+    if (!settings.autoSummaryEnabled || settings.globalEnabled === false) return;
+    if (_summaryInFlight) return;
 
     const chatId = getChatId();
     if (!chatId) return;
 
     const count = counters.get(chatId) || 0;
     const interval = settings.autoSummaryInterval || 20;
-    const activeBooks = getActiveTunnelVisionBooks();
-    if (activeBooks.length === 0) {
-        clearPrompt();
-        return;
-    }
+    if (count < interval) return;
 
-    if (count >= interval) {
-        // Don't inject if the Summarize tool is disabled — the model can't obey the instruction
-        const disabled = settings.disabledTools || {};
-        if (disabled['TunnelVision_Summarize']) {
-            console.warn('[TunnelVision] Auto-summary threshold reached but TunnelVision_Summarize is disabled. Skipping injection.');
-            clearPrompt();
-            return;
+    if (getActiveTunnelVisionBooks().length === 0) return;
+
+    _summaryInFlight = true;
+    pendingSummaries.set(chatId, { triggeredAt: count });
+    try {
+        console.log(`[TunnelVision] Auto-summary firing at ${count}/${interval} messages`);
+        const result = await runSummary({ source: 'auto' });
+        if (result.ok) {
+            toastr?.success?.(`Summary saved: "${result.title}" (UID ${result.uid})`, 'TunnelVision');
+            markAutoSummaryComplete();
+        } else {
+            // Do NOT reset the counter — a failed run should retry next turn
+            // rather than silently swallowing the interval.
+            console.warn(`[TunnelVision] Auto-summary did not run: ${result.reason}`);
+            pendingSummaries.delete(chatId);
         }
-
-        if (!pendingSummaries.has(chatId)) {
-            pendingSummaries.set(chatId, { triggeredAt: count });
-            console.log(`[TunnelVision] Auto-summary pending after ${count} messages`);
-        }
-
-        const prompt = `[AUTO-SUMMARY INSTRUCTION: ${count} messages have passed since the last summary. You MUST call TunnelVision_Summarize this turn to create a summary of recent events. Write a descriptive title and thorough summary of what has happened in the last ~${count} messages. After summarizing, continue responding to the user normally.]`;
-        setExtensionPrompt(TV_AUTOSUMMARY_KEY, prompt, extension_prompt_types.IN_PROMPT, 0);
-        return;
+    } catch (e) {
+        console.error('[TunnelVision] Auto-summary failed:', e);
+        pendingSummaries.delete(chatId);
+    } finally {
+        _summaryInFlight = false;
     }
-
-    clearPrompt();
 }
 
 function onChatChanged() {

--- a/commands.js
+++ b/commands.js
@@ -27,6 +27,8 @@ import { getActiveTunnelVisionBooks, resolveTargetBook } from './tool-registry.j
 import { ingestChatMessages } from './tree-builder.js';
 import { createEntry, mergeEntries, splitEntry, forgetEntry, updateEntry, findEntryByUid } from './entry-manager.js';
 import { generateAnalytical, getStoryContext, trigramSimilarity } from './agent-utils.js';
+import { runSummary } from './summary-runner.js';
+import { markAutoSummaryComplete } from './auto-summary.js';
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -329,59 +331,34 @@ async function handleSummarize(_namedArgs, unnamedArg, { activeBooks }) {
     const bookName = resolveAccessibleBook(activeBooks, 'write', 'summarize');
     if (!bookName) return;
 
-    const { book: lorebook, error } = resolveTargetBook(bookName, { checkWrite: true });
-    if (error) {
-        toastr.error(error, 'TunnelVision');
-        return;
-    }
-
-    const titleHint = String(unnamedArg || '').trim() || 'Recent events';
-    const messageCount = getContextMessages();
-    const recentChat = getRecentChat(messageCount);
-
-    if (!recentChat) {
-        toastr.warning('No chat messages to summarize.', 'TunnelVision');
-        return;
-    }
-
     toastr.info('Creating summary...', 'TunnelVision');
 
-    const storyCtx = getStoryContext();
-    const prompt = `${storyCtx ? storyCtx + '\n\n' : ''}Summarize the following conversation for a creative writing lorebook.
-Write in third person, past tense, capturing key actions, decisions, emotional beats, and plot developments.
-
-Topic/title hint: "${titleHint}"
-
-RECENT CONVERSATION:
-${recentChat}
-
-Return JSON:
-{
-  "title": "[Summary] <concise descriptive title>",
-  "summary": "<thorough third-person past-tense summary>",
-  "significance": "minor|moderate|major|critical"
-}`;
-
-    const response = await generateAnalytical({ prompt });
-    const parsed = parseJSON(response);
-
-    if (!parsed?.title || !parsed?.summary) {
-        toastr.error('Failed to create summary — could not parse LLM response.', 'TunnelVision');
+    // Shared implementation — same path interval auto-summary uses, so the two
+    // cannot drift. It files the entry under the Summaries node, guarantees the
+    // entry has usable keywords, posts a marker in the chat and hides the range
+    // it covered. The old inline version did none of those: it created the entry
+    // with `keys: []` and no node, producing an unfiled entry that could never fire.
+    let result;
+    try {
+        result = await runSummary({
+            titleHint: String(unnamedArg || '').trim(),
+            source: 'command',
+        });
+    } catch (e) {
+        toastr.error(`Failed to create summary: ${e.message}`, 'TunnelVision');
         return;
     }
 
-    try {
-        const sig = parsed.significance || 'moderate';
-        const content = `[Scene Summary — ${sig}]\n\n${parsed.summary.trim()}`;
-        const result = await createEntry(lorebook, {
-            content,
-            comment: parsed.title,
-            keys: [],
-        });
-        toastr.success(`Summary saved: "${result.comment}" (UID ${result.uid})`, 'TunnelVision');
-    } catch (e) {
-        toastr.error(`Failed to save summary: ${e.message}`, 'TunnelVision');
+    if (!result.ok) {
+        toastr.warning(result.reason || 'Nothing to summarize.', 'TunnelVision');
+        return;
     }
+
+    markAutoSummaryComplete();
+
+    let msg = `Summary saved: "${result.title}" (UID ${result.uid})`;
+    if (result.hidden) msg += ` — ${result.hidden}`;
+    toastr.success(msg, 'TunnelVision');
 }
 
 async function handleForget(_namedArgs, unnamedArg, { activeBooks }) {

--- a/entry-manager.js
+++ b/entry-manager.js
@@ -89,7 +89,7 @@ function assertBackgroundEntryMutable(entry, source) {
  * @param {string} [params.tv_tracker] - Optional tracking keyword for sidecar auto-cleanup
  * @returns {Promise<{uid: number, comment: string, nodeLabel: string}>}
  */
-export async function createEntry(bookName, { content, comment, keys, nodeId, tv_tracker }) {
+export async function createEntry(bookName, { content, comment, keys, nodeId, tv_tracker, constant = false }) {
     if (!content || !content.trim()) {
         throw new Error('Entry content cannot be empty.');
     }
@@ -128,7 +128,12 @@ export async function createEntry(bookName, { content, comment, keys, nodeId, tv
     
     // TunnelVision-managed entries: disable keyword triggering since retrieval is tree-based
     newEntry.selective = false;
-    newEntry.constant = false;
+    // Callers may opt in to `constant` for entries that must ALWAYS be in context
+    // rather than waiting on tree retrieval — scene summaries, which stand in for
+    // chat messages that have been hidden, are the motivating case. A summary that
+    // only sometimes injects is worse than no summary, because the messages it
+    // replaced are already gone from the prompt.
+    newEntry.constant = constant === true;
     newEntry.disable = false;
 
     // 1. Persist lorebook to disk FIRST (assigns final server-side UID)

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ import { bindUIEvents, refreshUI } from './ui-controller.js';
 import { initActivityFeed } from './activity-feed.js';
 import { initCommands } from './commands.js';
 import { initAutoSummary } from './auto-summary.js';
+import { initSummaryCollapse } from './summary-collapse.js';
 import { initPostTurnProcessor } from './post-turn-processor.js';
 import { initWorldState } from './world-state.js';
 import { initSmartContext } from './smart-context.js';
@@ -80,6 +81,7 @@ async function init() {
 
     // Wire up auto-summary interval tracking
     initAutoSummary();
+    initSummaryCollapse();
 
     // Wire up post-turn processor (tracker updates, fact extraction, scene archiving)
     initPostTurnProcessor();

--- a/settings.html
+++ b/settings.html
@@ -720,6 +720,22 @@
                                     Messages since last summary: <strong id="tv_auto_summary_count">0</strong>
                                 </div>
                             </div>
+                            <div class="tv-number-row" style="margin-top: 8px;">
+                                <label class="tv-number-label" for="tv_summary_keep_recent">Exclude:</label>
+                                <input id="tv_summary_keep_recent" type="number" class="tv-number-input" min="1" max="20" step="1" value="2" />
+                                <span class="tv-number-label">newest messages</span>
+                            </div>
+                            <div class="tv-help-text" style="margin-top: 4px;">
+                                The most recent messages are the live scene. They are neither summarised nor hidden, so the summary never runs ahead of the conversation.
+                            </div>
+                            <label class="tv-toggle" style="margin-top: 8px;">
+                                <input id="tv_summarize_opening_messages" type="checkbox" />
+                                <span class="tv-toggle-slider"></span>
+                                <span class="tv-toggle-label">Summarize opening messages</span>
+                            </label>
+                            <div class="tv-help-text" style="margin-top: 4px;">
+                                Off by default: everything before your first message is the greeting — one per character in a group chat — and is left visible. Turn on to fold those into summaries as well.
+                            </div>
                             <label class="tv-toggle" style="margin-top: 8px;">
                                 <input id="tv_auto_hide_summarized" type="checkbox" />
                                 <span class="tv-toggle-slider"></span>

--- a/summary-collapse.js
+++ b/summary-collapse.js
@@ -27,7 +27,7 @@
  * hiding.
  */
 
-import { eventSource, event_types } from '../../../../script.js';
+import { eventSource, event_types, updateViewMessageIds } from '../../../../script.js';
 import { getContext } from '../../../st-context.js';
 
 const STYLE_ID = 'tv-summary-collapse-style';
@@ -196,8 +196,38 @@ export async function postSummaryMarker(title, summaryText, hiddenRange) {
             },
         };
 
-        context.chat.push(message);
-        await context.addOneMessage(message);
+        // Place the marker immediately after the range it stands in for, not at
+        // the end of the chat.
+        //
+        // Summarising deliberately leaves the newest messages alone, and those
+        // are correctly still visible — they are the live scene. But appending
+        // the marker put it BELOW them, so the chat read
+        // [collapsed range][live messages][summary]: a summary arriving after
+        // messages it does not cover, which looks like the sweep missed them.
+        // Inserting after the range gives [collapsed range][summary][live
+        // messages] — the summary, then the scene continuing from it.
+        //
+        // Safe for the index-based ranges: everything already recorded (previous
+        // ranges, the watermark) is <= hiddenRange.end, so only the kept-recent
+        // tail shifts, and nothing refers to it by index.
+        const insertAt = hiddenRange && Number.isFinite(hiddenRange.end)
+            ? hiddenRange.end + 1
+            : context.chat.length;
+
+        if (insertAt < context.chat.length) {
+            context.chat.splice(insertAt, 0, message);
+            await context.addOneMessage(message, { insertAfter: hiddenRange.end });
+            // ⚠️ REQUIRED after a mid-chat insert. addOneMessage puts the element
+            // in the right place but does not renumber the ones after it, so
+            // every following .mes keeps a mesid that is now one too low —
+            // duplicates at the insertion point, gaps at the end. Anything that
+            // maps DOM to chat by mesid (this module's collapse, ST's own edit,
+            // swipe and delete) then acts on the wrong message.
+            updateViewMessageIds();
+        } else {
+            context.chat.push(message);
+            await context.addOneMessage(message);
+        }
         await context.saveChat?.();
         applyCollapse();
     } catch (e) {

--- a/summary-collapse.js
+++ b/summary-collapse.js
@@ -1,0 +1,173 @@
+/**
+ * TunnelVision — collapse summarized messages behind their summary.
+ *
+ * When a summary is created, the messages it covers are hidden with
+ * hideChatMessageRange(), which sets `is_system = true`. That removes them from
+ * the prompt (script.js builds `coreChat` by filtering `is_system` out) while
+ * leaving them nearly unchanged on screen.
+ *
+ * The message BODY renders identically to a live one, and deliberately so:
+ * script.js forces isSystem = false for anything whose ch_name is not the
+ * system user, under the comment "Let hidden messages have markdown". The only
+ * difference is driven off the .mes element's is_system="true" attribute — the
+ * avatar picks up opacity 0.9 and grayscale(25%), and the hover buttons swap
+ * .mes_hide for .mes_unhide plus .mes_ghost.
+ *
+ * A quarter-desaturated avatar and a changed hover button are easy to miss
+ * across a long chat, so in practice the chat looks untouched while a large
+ * part of it has silently left the model's context.
+ *
+ * That divergence is the whole problem: what you see stops matching what the
+ * model sees. This module closes it by folding each summarized range into a
+ * toggle attached to its summary marker, so the chat visibly pares down to the
+ * essentials and the hidden text is still one click away.
+ *
+ * Only ranges owned by a summary marker are collapsed. Messages hidden by hand
+ * (/hide) are left exactly as they are — this does not take over ST's own
+ * hiding.
+ */
+
+import { eventSource, event_types } from '../../../../script.js';
+import { getContext } from '../../../st-context.js';
+
+const STYLE_ID = 'tv-summary-collapse-style';
+const COLLAPSED_CLASS = 'tv-collapsed';
+const TOGGLE_CLASS = 'tv-summary-toggle';
+
+/** Marker message ids whose range the user has expanded. Reset per chat. */
+let expanded = new Set();
+
+let _initialized = false;
+
+export function initSummaryCollapse() {
+    if (_initialized) return;
+    _initialized = true;
+
+    injectStyle();
+
+    const reapply = () => { try { applyCollapse(); } catch (e) { console.error('[TunnelVision] collapse failed:', e); } };
+
+    if (event_types.CHAT_CHANGED) {
+        eventSource.on(event_types.CHAT_CHANGED, () => { expanded = new Set(); reapply(); });
+    }
+    for (const evt of ['CHARACTER_MESSAGE_RENDERED', 'USER_MESSAGE_RENDERED', 'MESSAGE_DELETED', 'MESSAGE_UPDATED', 'MORE_MESSAGES_LOADED']) {
+        if (event_types[evt]) eventSource.on(event_types[evt], reapply);
+    }
+
+    // Messages are re-rendered in ways that do not always emit an event
+    // (scroll-back, swipe redraw). A cheap periodic reconcile keeps the view
+    // honest without hooking ST's rendering internals.
+    setInterval(reapply, 2000);
+}
+
+function injectStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+        .mes.${COLLAPSED_CLASS} { display: none !important; }
+        .${TOGGLE_CLASS} {
+            display: inline-block;
+            margin-top: 6px;
+            padding: 2px 8px;
+            border: 1px solid var(--SmartThemeBorderColor, rgba(128,128,128,0.4));
+            border-radius: 10px;
+            font-size: 0.85em;
+            opacity: 0.75;
+            cursor: pointer;
+            user-select: none;
+        }
+        .${TOGGLE_CLASS}:hover { opacity: 1; }
+    `;
+    document.head.appendChild(style);
+}
+
+/**
+ * The range of messages a summary marker stands in for.
+ *
+ * Prefers the range recorded on the marker at creation. Summaries created
+ * before that was recorded — and any created by the tool path, which does its
+ * hiding separately — fall back to "the unbroken run of hidden messages
+ * immediately above the marker", which is what a summary+hide always produces.
+ *
+ * @returns {{start:number,end:number}|null}
+ */
+function getRange(chat, markerId) {
+    const message = chat[markerId];
+    if (!message?.extra?.tunnelvision_summary) return null;
+
+    const r = message.extra.tv_hidden_range;
+    if (r) {
+        const start = Number(r.start);
+        const end = Number(r.end);
+        if (Number.isFinite(start) && Number.isFinite(end) && start <= end) return { start, end };
+    }
+
+    // Fallback: walk back over the contiguous hidden run above the marker.
+    let end = -1;
+    let j = markerId - 1;
+    while (j >= 1 && chat[j]?.is_system && !chat[j]?.extra?.tunnelvision_summary) {
+        if (end < 0) end = j;
+        j--;
+    }
+    if (end < 0) return null;
+    return { start: j + 1, end };
+}
+
+/**
+ * Reconcile the DOM with the collapse state implied by the chat array.
+ */
+export function applyCollapse() {
+    const context = getContext();
+    const chat = context?.chat;
+    if (!Array.isArray(chat)) return;
+
+    // Any message covered by a summary range that is not expanded gets collapsed.
+    const shouldCollapse = new Set();
+
+    for (let i = 0; i < chat.length; i++) {
+        const range = getRange(chat, i);
+        if (!range) continue;
+
+        const isExpanded = expanded.has(i);
+        if (!isExpanded) {
+            for (let j = range.start; j <= range.end; j++) {
+                // Only collapse what is actually hidden — if the user unhid a
+                // message by hand, respect that and leave it visible.
+                if (chat[j]?.is_system) shouldCollapse.add(j);
+            }
+        }
+        renderToggle(i, range, isExpanded);
+    }
+
+    document.querySelectorAll('#chat .mes').forEach((el) => {
+        const id = Number(el.getAttribute('mesid'));
+        if (!Number.isFinite(id)) return;
+        el.classList.toggle(COLLAPSED_CLASS, shouldCollapse.has(id));
+    });
+}
+
+/** Put (or refresh) the toggle control on a summary marker message. */
+function renderToggle(markerId, range, isExpanded) {
+    const block = document.querySelector(`#chat .mes[mesid="${markerId}"]`);
+    if (!block) return;
+
+    const host = block.querySelector('.mes_text') || block;
+    let toggle = block.querySelector(`.${TOGGLE_CLASS}`);
+
+    if (!toggle) {
+        toggle = document.createElement('div');
+        toggle.className = TOGGLE_CLASS;
+        toggle.addEventListener('click', () => {
+            if (expanded.has(markerId)) expanded.delete(markerId);
+            else expanded.add(markerId);
+            applyCollapse();
+        });
+        host.appendChild(toggle);
+    }
+
+    const count = range.end - range.start + 1;
+    toggle.textContent = isExpanded
+        ? `▾ hide the ${count} summarized messages again`
+        : `▸ show the ${count} messages this replaced`;
+}

--- a/summary-collapse.js
+++ b/summary-collapse.js
@@ -224,8 +224,16 @@ function renderToggle(markerId, range, isExpanded) {
         host.appendChild(toggle);
     }
 
-    const count = range.end - range.start + 1;
+    // Count what actually collapses, not the raw span: a previous summary's
+    // marker can sit inside this range and is deliberately never collapsed, so
+    // the span would overstate the number by one per marker it contains.
+    const chat = getContext()?.chat;
+    let count = 0;
+    for (let j = range.start; j <= range.end; j++) {
+        if (chat?.[j]?.is_system && !chat[j]?.extra?.tunnelvision_summary) count++;
+    }
+
     toggle.textContent = isExpanded
-        ? `▾ hide the ${count} summarized messages again`
-        : `▸ show the ${count} messages this replaced`;
+        ? `▾ hide ${count} summarized messages`
+        : `▸ show ${count} hidden messages`;
 }

--- a/summary-collapse.js
+++ b/summary-collapse.js
@@ -147,6 +147,51 @@ export function applyCollapse() {
     });
 }
 
+/**
+ * Post a summary marker into the chat, standing in for the range it replaced.
+ *
+ * Lives here rather than in summary-runner so that BOTH summary paths can use
+ * it without an import cycle — the interval/slash-command path and the tool
+ * path used by the sidecar writer. A summary that hides messages without
+ * posting a marker leaves orphaned hidden messages: gone from the model's
+ * context, still on screen, with nothing explaining where they went.
+ *
+ * ⚠️ Posted as a SYSTEM message on purpose. SillyTavern excludes is_system
+ * messages from the prompt (script.js builds coreChat by filtering them out),
+ * and the summary already reaches context through its constant lorebook entry.
+ * A normal message would put the same text in the prompt twice.
+ *
+ * @param {string} title
+ * @param {string} summaryText
+ * @param {{start:number,end:number}|null} [hiddenRange]
+ */
+export async function postSummaryMarker(title, summaryText, hiddenRange) {
+    try {
+        const context = getContext();
+        if (typeof context.addOneMessage !== 'function') return;
+
+        const message = {
+            name: 'TunnelVision',
+            is_user: false,
+            is_system: true,
+            send_date: Date.now(),
+            mes: `📝 **${String(title).replace(/^\[Summary\]\s*/, '')}**\n\n${summaryText}`,
+            extra: {
+                isSmallSys: true,
+                tunnelvision_summary: true,
+                tv_hidden_range: hiddenRange || undefined,
+            },
+        };
+
+        context.chat.push(message);
+        await context.addOneMessage(message);
+        await context.saveChat?.();
+        applyCollapse();
+    } catch (e) {
+        console.error('[TunnelVision] Failed to post summary marker to chat:', e);
+    }
+}
+
 /** Put (or refresh) the toggle control on a summary marker message. */
 function renderToggle(markerId, range, isExpanded) {
     const block = document.querySelector(`#chat .mes[mesid="${markerId}"]`);

--- a/summary-collapse.js
+++ b/summary-collapse.js
@@ -134,7 +134,20 @@ export function applyCollapse() {
             for (let j = range.start; j <= range.end; j++) {
                 // Only collapse what is actually hidden — if the user unhid a
                 // message by hand, respect that and leave it visible.
-                if (chat[j]?.is_system) shouldCollapse.add(j);
+                //
+                // ...and never collapse ANOTHER summary's marker. A marker is
+                // is_system, so it matches the test above, but its own toggle is
+                // rendered on it: collapsing it hides the only control that could
+                // expand that summary, leaving it unreachable.
+                //
+                // Every range after the first contains the previous marker, by
+                // arithmetic rather than by chance: hideEnd is window.end - 1, so
+                // one message is always left visible as a live tail and the marker
+                // lands at hideEnd + 2, while the next window starts at
+                // watermark + 1 = hideEnd + 1 — one index before it.
+                if (chat[j]?.is_system && !chat[j]?.extra?.tunnelvision_summary) {
+                    shouldCollapse.add(j);
+                }
             }
         }
         renderToggle(i, range, isExpanded);

--- a/summary-runner.js
+++ b/summary-runner.js
@@ -26,6 +26,7 @@ import {
     hideSummarizedMessages,
     getWatermark,
 } from './tools/summarize.js';
+import { applyCollapse } from './summary-collapse.js';
 
 /** Hard ceiling on how many messages one summary will look at. */
 const MAX_WINDOW = 200;
@@ -204,21 +205,24 @@ Return JSON:
 
     console.log(`[TunnelVision] Summary (${source}) saved as UID ${result.uid} covering messages ${window.start}-${window.end}`);
 
-    // Put a marker in the chat where the scene was.
-    const shouldPost = postToChat !== undefined ? postToChat : settings.summaryPostToChat !== false;
-    if (shouldPost) {
-        await postSummaryMarker(title, String(parsed.summary).trim());
-    }
-
-    // Hide the range we actually summarized. Keep the most recent message
+    // Hide the summarized range FIRST, so the marker we post afterwards can
+    // carry that range and collapse it in the UI. Keep the most recent message
     // visible so the scene still has a live tail to continue from.
     let hidden = null;
+    let hiddenRange = null;
     const shouldHide = hide !== undefined ? hide : settings.autoHideSummarized !== false;
     if (shouldHide) {
         const hideEnd = Math.min(window.end, (getContext().chat?.length ?? 1) - 2);
         if (hideEnd >= window.start) {
             hidden = await hideSummarizedMessages(undefined, window.start, hideEnd);
+            if (hidden) hiddenRange = { start: window.start, end: hideEnd };
         }
+    }
+
+    // Put a marker in the chat standing in for the scene it replaced.
+    const shouldPost = postToChat !== undefined ? postToChat : settings.summaryPostToChat !== false;
+    if (shouldPost) {
+        await postSummaryMarker(title, String(parsed.summary).trim(), hiddenRange);
     }
 
     return { ok: true, title, uid: result.uid, hidden, book: lorebook };
@@ -232,7 +236,7 @@ Return JSON:
  * context through its lorebook entry. Posting it as a normal message would put
  * the same text in twice.
  */
-async function postSummaryMarker(title, summaryText) {
+async function postSummaryMarker(title, summaryText, hiddenRange) {
     try {
         const context = getContext();
         if (typeof context.addOneMessage !== 'function') return;
@@ -243,12 +247,20 @@ async function postSummaryMarker(title, summaryText) {
             is_system: true,
             send_date: Date.now(),
             mes: `📝 **${title.replace(/^\[Summary\]\s*/, '')}**\n\n${summaryText}`,
-            extra: { isSmallSys: true, tunnelvision_summary: true },
+            extra: {
+                isSmallSys: true,
+                tunnelvision_summary: true,
+                // The range this summary stands in for. summary-collapse.js reads
+                // this to fold those messages away behind a toggle, so the chat
+                // visibly matches what the model actually receives.
+                tv_hidden_range: hiddenRange || undefined,
+            },
         };
 
         context.chat.push(message);
         await context.addOneMessage(message);
         await context.saveChat?.();
+        applyCollapse();
     } catch (e) {
         console.error('[TunnelVision] Failed to post summary marker to chat:', e);
     }

--- a/summary-runner.js
+++ b/summary-runner.js
@@ -1,0 +1,247 @@
+/**
+ * TunnelVision — shared summarization runner.
+ *
+ * ONE implementation of "summarize the recent scene", used by BOTH the
+ * /tv-summarize slash command and interval auto-summary, so the two cannot
+ * drift apart. Previously they were separate code paths with different bugs:
+ * the slash command created entries with `keys: []` and no tree node (dead,
+ * unfiled entries), and auto-summary did not summarize at all — it injected an
+ * instruction telling the CHAT model to call TunnelVision_Summarize.
+ *
+ * ⚠️ Deliberate design point: this module NEVER depends on the host's function
+ * calling. It generates the summary itself through generateAnalytical() (the
+ * analytical/sidecar connection). With SillyTavern's function calling switched
+ * off — a supported and commonly recommended configuration — the old
+ * instruction-injection approach could never work, and the model would type
+ * `TunnelVision_Summarize: "..."` into the scene as narrative text.
+ */
+
+import { getContext } from '../../../st-context.js';
+import { getSettings } from './tree-store.js';
+import { createEntry } from './entry-manager.js';
+import { resolveTargetBook } from './tool-registry.js';
+import { generateAnalytical, getStoryContext, getLanguageInstruction } from './agent-utils.js';
+import {
+    ensureSummariesNode,
+    hideSummarizedMessages,
+    getWatermark,
+} from './tools/summarize.js';
+
+/** Hard ceiling on how many messages one summary will look at. */
+const MAX_WINDOW = 200;
+
+/**
+ * Collect the messages this summary should cover.
+ *
+ * Unlike the old getRecentChat(), this returns the *index range* as well as the
+ * text, so hiding uses a range we computed rather than a `messages_back` number
+ * the model may omit (the cause of auto-hide silently no-opping).
+ *
+ * The window starts after the last summary watermark so consecutive summaries
+ * do not re-cover the same messages.
+ *
+ * @param {number} fallbackCount How far back to look when no watermark is set.
+ * @returns {{ text: string, start: number, end: number, visibleCount: number }|null}
+ */
+function collectChatWindow(fallbackCount) {
+    const context = getContext();
+    const chat = context?.chat;
+    if (!chat || chat.length === 0) return null;
+
+    const lastIndex = chat.length - 1;
+    const watermark = getWatermark();
+
+    let start = watermark >= 0
+        ? watermark + 1
+        : Math.max(0, chat.length - fallbackCount);
+
+    // Never swallow the opening message/greeting.
+    if (start < 1) start = chat.length > 1 ? 1 : 0;
+
+    const end = Math.min(lastIndex, start + MAX_WINDOW - 1);
+    if (start > end) return null;
+
+    const lines = [];
+    let visibleCount = 0;
+    for (let i = start; i <= end; i++) {
+        const msg = chat[i];
+        if (!msg || msg.is_system) continue;
+        visibleCount++;
+        const name = msg.is_user ? (context.name1 || 'User') : (msg.name || context.name2 || 'AI');
+        lines.push(`${name}: ${(msg.mes || '').substring(0, 600)}`);
+    }
+
+    if (visibleCount === 0) return null;
+    return { text: lines.join('\n'), start, end, visibleCount };
+}
+
+/** Lenient JSON parse — the analytical model sometimes fences or prefaces its output. */
+function parseJSON(text) {
+    if (!text) return null;
+    const stripped = String(text).replace(/```(?:json)?\s*/gi, '').replace(/```\s*/g, '').trim();
+    try {
+        return JSON.parse(stripped);
+    } catch {
+        const first = stripped.search(/[{[]/);
+        if (first >= 0) {
+            try { return JSON.parse(stripped.substring(first)); } catch { /* fall through */ }
+        }
+        return null;
+    }
+}
+
+/**
+ * Build the keyword set for a summary entry.
+ *
+ * ⚠️ A non-constant lorebook entry with no keys can NEVER be injected — it is a
+ * dead entry that still occupies the book and reads as a stored memory. The
+ * slash command used to create exactly that (`keys: []`). This guarantees at
+ * least one usable key.
+ *
+ * @param {string[]|undefined} participants
+ * @param {string} title
+ * @param {string} significance
+ * @returns {string[]}
+ */
+export function buildSummaryKeys(participants, title, significance) {
+    const keys = [];
+
+    if (Array.isArray(participants)) {
+        for (const p of participants) {
+            const clean = String(p || '').trim();
+            if (clean) keys.push(clean);
+        }
+    }
+
+    // Fall back to distinctive words from the title so the entry can still fire.
+    if (keys.length === 0) {
+        const stop = new Set(['the', 'and', 'for', 'with', 'a', 'an', 'of', 'to', 'in', 'on', 'at', 'summary', 'scene']);
+        const words = String(title || '')
+            .replace(/^\[[^\]]*\]\s*/, '')
+            .split(/[^A-Za-z0-9']+/)
+            .map(w => w.trim())
+            .filter(w => w.length > 3 && !stop.has(w.toLowerCase()));
+        keys.push(...words.slice(0, 5));
+    }
+
+    keys.push(`summary:${significance}`);
+    return [...new Set(keys)];
+}
+
+/**
+ * Run one summarization pass.
+ *
+ * @param {Object} opts
+ * @param {string} [opts.titleHint] Optional steer for the title.
+ * @param {string} [opts.source] 'command' | 'auto' — for logging only.
+ * @param {boolean} [opts.hide] Hide the summarized range afterwards. Default: follow autoHideSummarized.
+ * @param {boolean} [opts.postToChat] Insert a marker message in the chat. Default: follow settings.
+ * @returns {Promise<{ ok: boolean, reason?: string, title?: string, uid?: number, hidden?: string|null }>}
+ */
+export async function runSummary({ titleHint = '', source = 'command', hide, postToChat } = {}) {
+    const settings = getSettings();
+
+    const { book: lorebook, error } = resolveTargetBook(undefined, { checkWrite: true });
+    if (error) return { ok: false, reason: error };
+
+    const fallbackCount = Number(settings.commandContextMessages) || 50;
+    const window = collectChatWindow(fallbackCount);
+    if (!window) return { ok: false, reason: 'No new messages to summarize.' };
+
+    const storyCtx = getStoryContext();
+    const prompt = `${storyCtx ? storyCtx + '\n\n' : ''}Summarize the following conversation for a creative writing lorebook.
+Write in third person, past tense, capturing key actions, decisions, emotional beats, and plot developments.
+
+${titleHint ? `Topic/title hint: "${titleHint}"\n\n` : ''}RECENT CONVERSATION:
+${window.text}
+
+Return JSON:
+{
+  "title": "<concise descriptive title, no bracket prefix>",
+  "summary": "<thorough third-person past-tense summary>${getLanguageInstruction()}",
+  "participants": ["<character names involved>"],
+  "significance": "minor|moderate|major|critical"
+}`;
+
+    const response = await generateAnalytical({ prompt });
+    const parsed = parseJSON(response);
+    if (!parsed?.title || !parsed?.summary) {
+        return { ok: false, reason: 'Could not parse the summarizer response.' };
+    }
+
+    const significance = ['minor', 'moderate', 'major', 'critical'].includes(parsed.significance)
+        ? parsed.significance
+        : 'moderate';
+
+    const participants = Array.isArray(parsed.participants) ? parsed.participants : [];
+    const participantList = participants.length ? participants.join(', ') : '(unspecified)';
+    const content = `[Scene Summary — ${significance}]\nParticipants: ${participantList}\n\n${String(parsed.summary).trim()}`;
+    const title = `[Summary] ${String(parsed.title).replace(/^\[[^\]]*\]\s*/, '').trim()}`;
+
+    // File it under the Summaries node — this also creates a minimal tree when
+    // the book has none, which keeps the book visible to the sidecar writer.
+    const nodeId = ensureSummariesNode(lorebook);
+
+    let result;
+    try {
+        result = await createEntry(lorebook, {
+            content,
+            comment: title,
+            keys: buildSummaryKeys(participants, parsed.title, significance),
+            nodeId,
+        });
+    } catch (e) {
+        return { ok: false, reason: `Failed to save summary: ${e.message}` };
+    }
+
+    console.log(`[TunnelVision] Summary (${source}) saved as UID ${result.uid} covering messages ${window.start}-${window.end}`);
+
+    // Put a marker in the chat where the scene was.
+    const shouldPost = postToChat !== undefined ? postToChat : settings.summaryPostToChat !== false;
+    if (shouldPost) {
+        await postSummaryMarker(title, String(parsed.summary).trim());
+    }
+
+    // Hide the range we actually summarized. Keep the most recent message
+    // visible so the scene still has a live tail to continue from.
+    let hidden = null;
+    const shouldHide = hide !== undefined ? hide : settings.autoHideSummarized !== false;
+    if (shouldHide) {
+        const hideEnd = Math.min(window.end, (getContext().chat?.length ?? 1) - 2);
+        if (hideEnd >= window.start) {
+            hidden = await hideSummarizedMessages(undefined, window.start, hideEnd);
+        }
+    }
+
+    return { ok: true, title, uid: result.uid, hidden, book: lorebook };
+}
+
+/**
+ * Insert the summary into the chat in place of what it covers.
+ *
+ * ⚠️ Posted as a SYSTEM message (is_system: true) on purpose: SillyTavern
+ * excludes system messages from the prompt, and the summary already reaches
+ * context through its lorebook entry. Posting it as a normal message would put
+ * the same text in twice.
+ */
+async function postSummaryMarker(title, summaryText) {
+    try {
+        const context = getContext();
+        if (typeof context.addOneMessage !== 'function') return;
+
+        const message = {
+            name: 'TunnelVision',
+            is_user: false,
+            is_system: true,
+            send_date: Date.now(),
+            mes: `📝 **${title.replace(/^\[Summary\]\s*/, '')}**\n\n${summaryText}`,
+            extra: { isSmallSys: true, tunnelvision_summary: true },
+        };
+
+        context.chat.push(message);
+        await context.addOneMessage(message);
+        await context.saveChat?.();
+    } catch (e) {
+        console.error('[TunnelVision] Failed to post summary marker to chat:', e);
+    }
+}

--- a/summary-runner.js
+++ b/summary-runner.js
@@ -25,11 +25,19 @@ import {
     ensureSummariesNode,
     hideSummarizedMessages,
     getWatermark,
+    firstSummarizableIndex,
 } from './tools/summarize.js';
 import { postSummaryMarker } from './summary-collapse.js';
 
 /** Hard ceiling on how many messages one summary will look at. */
 const MAX_WINDOW = 200;
+
+/**
+ * How many of the newest messages a summary leaves alone, when
+ * `summaryKeepRecent` is not set. Never less than 1 — hiding the whole visible
+ * chat would leave the model with no live scene to continue from.
+ */
+const DEFAULT_KEEP_RECENT = 2;
 
 /**
  * Collect the messages this summary should cover.
@@ -49,6 +57,7 @@ function collectChatWindow(fallbackCount) {
     const chat = context?.chat;
     if (!chat || chat.length === 0) return null;
 
+    const settings = getSettings();
     const lastIndex = chat.length - 1;
     const watermark = getWatermark();
 
@@ -56,10 +65,19 @@ function collectChatWindow(fallbackCount) {
         ? watermark + 1
         : Math.max(0, chat.length - fallbackCount);
 
-    // Never swallow the opening message/greeting.
-    if (start < 1) start = chat.length > 1 ? 1 : 0;
+    // Never swallow the opening messages. In a group that is one greeting per
+    // member, so guarding index 0 alone would eat every greeting but the first.
+    const openingEnd = firstSummarizableIndex(chat);
+    if (start < openingEnd) start = openingEnd;
 
-    const end = Math.min(lastIndex, start + MAX_WINDOW - 1);
+    // Leave the most recent messages alone: they are the live scene, and
+    // summarising what is still on screen reads as the summary running ahead of
+    // the conversation. This is also what keeps the window and the hidden range
+    // identical — previously the window ran one past the hidden range, so the
+    // newest message was summarised once here and again in the next summary.
+    const keepRecent = Math.max(1, Number(settings.summaryKeepRecent ?? DEFAULT_KEEP_RECENT) || DEFAULT_KEEP_RECENT);
+
+    const end = Math.min(lastIndex - keepRecent, start + MAX_WINDOW - 1);
     if (start > end) return null;
 
     const lines = [];
@@ -212,6 +230,9 @@ Return JSON:
     let hiddenRange = null;
     const shouldHide = hide !== undefined ? hide : settings.autoHideSummarized !== false;
     if (shouldHide) {
+        // The window already excludes the kept-recent messages, so hide exactly
+        // what was summarised. The `length - 2` term is only a floor for the case
+        // where the chat shrank while the summary was generating.
         const hideEnd = Math.min(window.end, (getContext().chat?.length ?? 1) - 2);
         if (hideEnd >= window.start) {
             hidden = await hideSummarizedMessages(undefined, window.start, hideEnd);

--- a/summary-runner.js
+++ b/summary-runner.js
@@ -26,7 +26,7 @@ import {
     hideSummarizedMessages,
     getWatermark,
 } from './tools/summarize.js';
-import { applyCollapse } from './summary-collapse.js';
+import { postSummaryMarker } from './summary-collapse.js';
 
 /** Hard ceiling on how many messages one summary will look at. */
 const MAX_WINDOW = 200;
@@ -228,40 +228,5 @@ Return JSON:
     return { ok: true, title, uid: result.uid, hidden, book: lorebook };
 }
 
-/**
- * Insert the summary into the chat in place of what it covers.
- *
- * ⚠️ Posted as a SYSTEM message (is_system: true) on purpose: SillyTavern
- * excludes system messages from the prompt, and the summary already reaches
- * context through its lorebook entry. Posting it as a normal message would put
- * the same text in twice.
- */
-async function postSummaryMarker(title, summaryText, hiddenRange) {
-    try {
-        const context = getContext();
-        if (typeof context.addOneMessage !== 'function') return;
-
-        const message = {
-            name: 'TunnelVision',
-            is_user: false,
-            is_system: true,
-            send_date: Date.now(),
-            mes: `📝 **${title.replace(/^\[Summary\]\s*/, '')}**\n\n${summaryText}`,
-            extra: {
-                isSmallSys: true,
-                tunnelvision_summary: true,
-                // The range this summary stands in for. summary-collapse.js reads
-                // this to fold those messages away behind a toggle, so the chat
-                // visibly matches what the model actually receives.
-                tv_hidden_range: hiddenRange || undefined,
-            },
-        };
-
-        context.chat.push(message);
-        await context.addOneMessage(message);
-        await context.saveChat?.();
-        applyCollapse();
-    } catch (e) {
-        console.error('[TunnelVision] Failed to post summary marker to chat:', e);
-    }
-}
+// postSummaryMarker lives in summary-collapse.js so the tool path can share it
+// without an import cycle. See the note there on why it is a system message.

--- a/summary-runner.js
+++ b/summary-runner.js
@@ -93,10 +93,11 @@ function parseJSON(text) {
 /**
  * Build the keyword set for a summary entry.
  *
- * ⚠️ A non-constant lorebook entry with no keys can NEVER be injected — it is a
- * dead entry that still occupies the book and reads as a stored memory. The
- * slash command used to create exactly that (`keys: []`). This guarantees at
- * least one usable key.
+ * TunnelVision's own retrieval is tree-based, so its entries do not rely on
+ * SillyTavern's keyword matcher — but keys are still what makes an entry
+ * findable by cross-book search, and what keeps the lorebook useful if the
+ * extension is ever disabled. The slash command used to pass `keys: []`.
+ * This guarantees at least one usable key.
  *
  * @param {string[]|undefined} participants
  * @param {string} title
@@ -189,6 +190,13 @@ Return JSON:
             comment: title,
             keys: buildSummaryKeys(participants, parsed.title, significance),
             nodeId,
+            // ⚠️ Summaries are ALWAYS-ON by design. This entry stands in for chat
+            // messages that have just been hidden, so it has to be present every
+            // turn — a keyword-triggered summary that fails to fire would mean the
+            // scene is gone from context with nothing in its place. Being constant
+            // also brings it inside isStaticEntry()'s protection, so background
+            // automation will not rewrite the record of what happened.
+            constant: true,
         });
     } catch (e) {
         return { ok: false, reason: `Failed to save summary: ${e.message}` };

--- a/tools/summarize.js
+++ b/tools/summarize.js
@@ -19,6 +19,7 @@ import { markAutoSummaryComplete } from '../auto-summary.js';
 import { getLanguageInstruction } from '../agent-utils.js';
 import { getContext } from '../../../../st-context.js';
 import { hideChatMessageRange } from '../../../../chats.js';
+import { postSummaryMarker } from '../summary-collapse.js';
 
 export const TOOL_NAME = 'TunnelVision_Summarize';
 export const COMPACT_DESCRIPTION = 'Create a scene or event summary to preserve significant narrative beats in long-term memory.';
@@ -105,7 +106,7 @@ function getSummarizedHideRange(messagesBack, overrideStart, overrideEnd) {
     return { start: hideStart, end: hideEnd, visibleCount, currentMsgId };
 }
 
-function setPendingSummaryHide(range) {
+function setPendingSummaryHide(range, summaryInfo) {
     if (!range) return;
     const context = getContext();
     if (!context.chatMetadata) return;
@@ -114,6 +115,11 @@ function setPendingSummaryHide(range) {
         end: range.end,
         visibleCount: range.visibleCount,
         currentMsgId: range.currentMsgId,
+        // Carried so the flush can post a chat marker for the range it hides.
+        // Without one, this path hides messages and leaves nothing on screen to
+        // explain where they went.
+        title: summaryInfo?.title,
+        summary: summaryInfo?.summary,
     };
     context.saveMetadataDebounced?.();
 }
@@ -170,6 +176,16 @@ export async function flushPendingSummaryHide() {
         await hideChatMessageRange(start, maxSafeEnd, false);
         setWatermark(maxSafeEnd);
         console.log(`[TunnelVision] Hid messages ${start}-${maxSafeEnd} (${visibleCount} visible) after final response`);
+
+        // Post a marker standing in for what was just hidden. This path used to
+        // hide silently, which left orphaned hidden messages — out of the model's
+        // context, still rendered, with nothing accounting for them. It also made
+        // the collapse fallback misattribute those messages to whichever later
+        // summary happened to sit above them.
+        if (pending.title) {
+            await postSummaryMarker(pending.title, pending.summary || '', { start, end: maxSafeEnd });
+        }
+
         return `Hidden ${visibleCount} summarized messages (${start}-${maxSafeEnd}).`;
     } catch (e) {
         console.error('[TunnelVision] Failed to flush pending summarized messages:', e);
@@ -350,7 +366,7 @@ When you notice related events forming a pattern or storyline, group them into "
                 // generation and can make the model continue from an old scene.
                 const hideRange = getSummarizedHideRange(args.messages_back);
                 if (hideRange) {
-                    setPendingSummaryHide(hideRange);
+                    setPendingSummaryHide(hideRange, { title: args.title, summary: args.summary });
                     response += ` ${hideRange.visibleCount} summarized messages will be hidden after the response.`;
                 }
 

--- a/tools/summarize.js
+++ b/tools/summarize.js
@@ -48,6 +48,33 @@ export function setWatermark(messageId) {
 }
 
 /**
+ * The lowest message index a summary may cover.
+ *
+ * Everything before the first user message is opening material — a character's
+ * greeting, and in a GROUP chat one greeting per member. By default those are
+ * left alone: they set the scene, and they are the part of the chat a reader is
+ * most likely to scroll back to.
+ *
+ * ⚠️ Index 0 alone is NOT the right guard, which is what this replaces. It
+ * protects a single-character greeting but silently swallows every group
+ * member's greeting except the first, so a two-hander opens with one greeting
+ * visible and the other summarised away — the opening looks half-eaten.
+ *
+ * Set `summarizeOpeningMessages` to fold them in like any other message.
+ *
+ * @param {Array} chat
+ * @returns {number} Lowest index a summary may start at.
+ */
+export function firstSummarizableIndex(chat) {
+    if (!Array.isArray(chat)) return 1;
+    if (getSettings()?.summarizeOpeningMessages === true) return 0;
+    for (let i = 0; i < chat.length; i++) {
+        if (chat[i]?.is_user) return i;
+    }
+    return chat.length;
+}
+
+/**
  * Compute the message range that can be hidden after a summary.
  * @param {number|undefined} messagesBack - How many messages back the summary covers.
  * @param {number|undefined} overrideStart - Explicit start message ID (used by auto-summary).
@@ -92,8 +119,10 @@ function getSummarizedHideRange(messagesBack, overrideStart, overrideEnd) {
 
     // Sanity checks
     if (hideStart > hideEnd || hideStart < 0 || hideEnd < 0) return null;
-    // Don't hide message 0 (first message / greeting)
-    if (hideStart === 0) hideStart = 1;
+    // Never hide the opening messages — in a group that is one greeting per
+    // member, not just index 0.
+    const openingEnd = firstSummarizableIndex(chat);
+    if (hideStart < openingEnd) hideStart = openingEnd;
     if (hideStart > hideEnd) return null;
 
     // Don't re-hide already hidden messages — count only visible ones

--- a/tools/summarize.js
+++ b/tools/summarize.js
@@ -335,6 +335,9 @@ When you notice related events forming a pattern or storyline, group them into "
                     keys,
                     nodeId: targetNodeId,
                     tv_tracker: args.tv_tracker,
+                    // Same rule as the interval/slash-command path: a summary stands
+                    // in for messages that get hidden, so it must always be present.
+                    constant: true,
                 });
                 markAutoSummaryComplete();
                 let response = `Summarized: "${args.title}" (UID ${result.uid}) → "${result.nodeLabel}" in "${lorebook}". Significance: ${significance}.`;

--- a/tree-store.js
+++ b/tree-store.js
@@ -303,6 +303,12 @@ export const SETTING_DEFAULTS = {
     ephemeralToolFilter: ['TunnelVision_Search', 'TunnelVision_Summarize', 'TunnelVision_MergeSplit'],
     stealthMode: false,
     autoHideSummarized: true,
+    // Newest messages a summary leaves alone. Minimum 1 — summarising the whole
+    // visible chat leaves the model no live scene to continue from.
+    summaryKeepRecent: 2,
+    // Fold the opening greetings (one per member in a group) into summaries too.
+    // Off by default: they set the scene and are what a reader scrolls back to.
+    summarizeOpeningMessages: false,
     passthroughConstant: true,
     allowKeywordTriggers: false,
     autoDetectPattern: '',

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -180,6 +180,8 @@ export function bindUIEvents() {
     // Auto-summary settings
     $('#tv_auto_summary_enabled').on('change', onAutoSummaryToggle);
     $('#tv_auto_summary_interval').on('change', onAutoSummaryIntervalChange);
+    $('#tv_summary_keep_recent').on('change', onSummaryKeepRecentChange);
+    $('#tv_summarize_opening_messages').on('change', onSummarizeOpeningMessagesToggle);
     $('#tv_auto_hide_summarized').on('change', onAutoHideSummarizedToggle);
     $('#tv_passthrough_constant').on('change', onPassthroughConstantToggle);
     $('#tv_allow_keyword_triggers').on('change', onAllowKeywordTriggersToggle);
@@ -403,6 +405,8 @@ export function refreshUI() {
     $('#tv_auto_summary_enabled').prop('checked', autoEnabled);
     $('#tv_auto_summary_options').toggle(autoEnabled);
     $('#tv_auto_summary_interval').val(settings.autoSummaryInterval ?? 20);
+    $('#tv_summary_keep_recent').val(settings.summaryKeepRecent ?? 2);
+    $('#tv_summarize_opening_messages').prop('checked', settings.summarizeOpeningMessages === true);
     $('#tv_auto_summary_count').text(getAutoSummaryCount());
     $('#tv_auto_hide_summarized').prop('checked', settings.autoHideSummarized !== false);
     $('#tv_passthrough_constant').prop('checked', settings.passthroughConstant !== false);
@@ -1029,6 +1033,24 @@ function onAutoSummaryIntervalChange() {
     $('#tv_auto_summary_interval').val(clamped);
     const settings = getSettings();
     settings.autoSummaryInterval = clamped;
+    saveSettingsDebounced();
+}
+
+function onSummaryKeepRecentChange() {
+    const raw = Number($('#tv_summary_keep_recent').val());
+    // Floor of 1: at 0 a summary would hide the whole visible chat, leaving the
+    // model nothing live to continue from.
+    const clamped = Math.min(Math.max(Math.round(raw) || 2, 1), 20);
+    $('#tv_summary_keep_recent').val(clamped);
+    const settings = getSettings();
+    settings.summaryKeepRecent = clamped;
+    saveSettingsDebounced();
+}
+
+function onSummarizeOpeningMessagesToggle() {
+    const enabled = $(this).prop('checked');
+    const settings = getSettings();
+    settings.summarizeOpeningMessages = enabled;
     saveSettingsDebounced();
 }
 


### PR DESCRIPTION
Auto-summary did not summarize, and when summarizing did work it left the chat looking
untouched while a large part of it had left the model's context. This makes the feature
work and makes its effect visible. Eight commits, each with its reasoning in the message.

## Auto-summary never summarized

It injected an `[AUTO-SUMMARY INSTRUCTION]` telling the chat model it MUST call
`TunnelVision_Summarize`, guarded only by TunnelVision's own per-tool toggle. With
SillyTavern's function calling disabled the request carries no tools array, so the model
cannot comply — and types the tool call into the scene as narrative text.

Auto-summary now performs the summary itself through `generateAnalytical`, the same
analytical connection `/tv-summarize` already used, so it does not depend on host tool
support. It runs on `MESSAGE_RECEIVED` rather than `GENERATION_STARTED`, with an in-flight
guard, and leaves the counter alone when a run fails so the interval retries instead of
silently swallowing it.

The slash command and the interval now share one implementation (`summary-runner.js`) so
they cannot drift. They previously did: the slash command created entries with `keys: []`
and no tree node, producing an unfiled entry with no keywords — which a non-constant
lorebook entry can never fire from.

## Summaries are constant entries

A summary stands in for messages that have been hidden, so it has to be in context every
turn. A keyword-triggered summary that fails to fire means the scene is gone from the
prompt with **nothing in its place** — strictly worse than not summarizing.

`createEntry` gained a `constant` option, defaulting to `false` so every existing caller
keeps its behaviour; only the summary paths opt in. Being constant also brings summaries
inside `isStaticEntry()`, so background automation will not rewrite or consolidate the
record of what happened.

(`createEntry` sets `selective = false` for all TunnelVision entries because retrieval is
tree-based rather than keyword-matched. That is why this needed an explicit opt-in rather
than just supplying keys.)

## What the chat shows

Hiding a range removes it from the prompt (`script.js:4437` builds `coreChat` by filtering
`is_system` out) but barely changes the chat on screen. The message **body** renders
identically to a live one, deliberately — `script.js:1775` forces `isSystem = false` for
anything whose `ch_name` is not the system user, under the comment *"Let hidden messages
have markdown"*. The only difference is off the `.mes` element's `is_system="true"`
attribute: the avatar gets `opacity: 0.9` and `grayscale(25%)` (`style.css:366`), and the
hover buttons swap `.mes_hide` for `.mes_unhide` plus `.mes_ghost` (`style.css:635-645`).

A desaturated avatar is easy to miss across a long chat, so the scene looked untouched
while a large part of it had left the model's context. That divergence — what you see
versus what the model sees — is the actual problem; the token saving already worked.

Summarized ranges now fold behind a toggle on their summary marker, reading
`show N hidden messages` / `hide N summarized messages`. The marker records the range it
stands in for at creation, and is posted from **both** summary paths: the tool path used by
the sidecar writer previously hid its range and posted no marker at all, leaving messages
that were gone from context, still on screen, with nothing accounting for them (observed
live: 16 messages hidden with no visible trace).

**Why this isn't just a CSS rule** — mostly it is: the folding is one injected
`.mes.<collapsed> { display: none !important; }` toggled per element. What needs JS is the
scoping, and that is the part that matters. A rule keyed on `is_system="true"` would catch
**every** hidden message including hand-`/hide`n ones, which fights ST's own intent. CSS
also cannot know which hidden messages a given marker owns, so it cannot report a count.
Only ranges owned by a summary marker collapse; `/hide` ranges are untouched.

Three details that took a bug each to get right:

- **A marker is never collapsed by another summary's range.** A marker is `is_system`, so it
  matched "collapse what is hidden" and got swept up — taking with it the only toggle that
  could expand that summary, leaving it unreachable. Every range after the first contains
  the previous marker by arithmetic, not chance, so this happened constantly.
- **The count is what actually collapses**, not `end - start + 1`. Those differ by one per
  marker inside the range.
- **`addOneMessage`'s `insertAfter` does not renumber the messages after it.** Every
  following `.mes` keeps a `mesid` one too low — duplicates at the insertion point, gaps at
  the end (`0,1,2,3,4,5,5,6,8,9,10,10,…`). Anything mapping DOM to chat by `mesid` then acts
  on the wrong message, including ST's own edit, swipe and delete. `updateViewMessageIds()`
  after the insert fixes it.

## Two new fields in the Auto-Summary settings

Both replace hardcoded behaviour, and both defaults preserve the intent of what was there.

1. **`Exclude: N newest messages`** (`summaryKeepRecent`, default **2**, min 1).
   The newest messages are the live scene: they are neither summarized nor hidden, so a
   summary never describes what is still on screen. This also fixes a double-coverage bug —
   the window used to run one message past the hidden range, so the newest message was
   summarized once and then again by the next summary, because the watermark follows the
   hidden range rather than the window. The minimum of 1 is deliberate: at 0 a summary would
   hide the entire visible chat, leaving the model no live scene to continue from.
2. **`Summarize opening messages`** (`summarizeOpeningMessages`, default **false**).
   The old guard was `if (start < 1) start = 1` — protect message 0. In a **group** chat
   every member posts a greeting, so it protected the first character's and summarized the
   rest away: a two-hander opens with one greeting visible and the other gone, which reads
   as the summary having eaten half the scene. The floor is now the first *user* message, so
   the greetings survive together. Turn this on to fold them in like any other message.

The marker is also placed immediately after the range it covers rather than appended at the
end of the chat. With recent messages deliberately kept visible, appending produced
`[collapsed range][live messages][summary]` — a summary arriving below messages it does not
cover, which reads as though the sweep missed them. It is now
`[collapsed range][summary][live messages]`.

## Verified in live play

A full run in a fresh two-character group chat, chat model via llama.cpp with ST function
calling **off** — the condition the first commit exists to fix:

```
 0  Puff          VISIBLE     greeting
 1  Lacey         VISIBLE     greeting   <- both survive
 2-4               collapsed
 5  MARKER 2-4    VISIBLE                <- directly after its range
 6-11              collapsed
12  MARKER 5-11   VISIBLE                <- directly after its range
13-19             VISIBLE     live scene, neither summarized nor hidden
```

- Auto-summary fired on its own at the interval, twice, with no tools array in the request.
- Entries are `constant: true`, keyed, filed under a `Summaries` node.
- Toggle counts `3` and `6` — the second being 7 indices minus the marker at 5.
- The marker at 5 sits inside range 5–11 and stays visible; each summary expands and
  collapses independently, with no state leaking between them.
- `mesid` checked explicitly after the inserts: no duplicates, no gaps, no DOM/array
  mismatch.
- Also exercised: `/tv-summarize`, and the tool path via a model `TunnelVision_Summarize`
  call, which posts its marker from the deferred flush.

⚠️ **Method note if you touch these files:** `auto-summary → summary-runner →
tools/summarize → auto-summary` is a module cycle that resolves only because the shared
bindings are hoisted function declarations. `node --check` will not catch a break — the page
has to load.