### PR TITLE
Let the user cancel a sidecar retrieval, and stop the reply with it

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ import { initSmartContext } from './smart-context.js';
 import { initMemoryLifecycle } from './memory-lifecycle.js';
 import { runSidecarRetrieval, clearRetrievalPrompt } from './sidecar-retrieval.js';
 import { runSidecarWriter, revertInvalidSnapshots, hydrateSnapshots, cleanInvalidSidecarMemories } from './sidecar-writer.js';
+import { abortSidecarFetches, isRetrievalScopeOpen } from './llm-sidecar.js';
 import { separateConditions, isEvaluableCondition, formatCondition, EVALUABLE_TYPES, CONDITION_LABELS, getKeywordProbability, setKeywordProbability } from './conditions.js';
 import { loadWorldInfo, saveWorldInfo, world_names } from '../../../world-info.js';
 import { findEntryByUid } from './entry-manager.js';
@@ -54,7 +55,25 @@ let _generationInProgress = false;
 // so we mirror it here to know when we're on the final pass.
 let _toolRecursionDepth = 0;
 let _skipPreCommandGeneration = false;
+// Set when the user hits stop while TunnelVision holds ST's GENERATION_STARTED await.
+let _stopRequestedDuringRetrieval = false;
+
 let _stateRefreshTimer = null;
+
+// ST's supported cancel hook: registered via manifest.generate_interceptor and
+// called as globalThis[key](chat, contextSize, abort, type) from Generate()
+// (script.js: `const aborted = await runGenerationInterceptors(...)`). Calling
+// abort(true) makes Generate return before it builds any request — the only
+// point in the pipeline where an extension can stop the main model cleanly.
+// Aborting ST's abortController from GENERATION_STOPPED does not: Generate
+// replaces it right after the GENERATION_STARTED await it was blocked on.
+globalThis.TunnelVision_generateInterceptor = function (_chat, _contextSize, abort, _type) {
+    if (!_stopRequestedDuringRetrieval) return;
+    _stopRequestedDuringRetrieval = false;
+    console.log('[TunnelVision] Stop pressed during retrieval — cancelling the main model request');
+    toastr.info('Retrieval stopped — the reply was not sent.', 'TunnelVision');
+    abort(true);
+};
 
 async function init() {
     // Ensure settings exist
@@ -174,6 +193,23 @@ async function init() {
                 window.TunnelVision_isRecursiveToolPass = false;
             });
         }
+    }
+
+    // Abort any in-flight sidecar retrieval when the user stops generation.
+    // Separate from the guard-clearing block above (which only runs its
+    // GENERATION_STOPPED branch when GENERATION_ENDED is absent). This one is
+    // always registered so stop actually cancels the sidecar fetch.
+    if (event_types.GENERATION_STOPPED) {
+        eventSource.on(event_types.GENERATION_STOPPED, () => {
+            // Aborting our own fetches is not enough: ST's Generate() is parked on the
+            // GENERATION_STARTED await we are holding and will carry on to the main
+            // request once we return. Remember the stop so the generate interceptor
+            // can cancel that request — see TunnelVision_generateInterceptor.
+            const inRetrieval = isRetrievalScopeOpen();
+            if (inRetrieval) _stopRequestedDuringRetrieval = true;
+            console.debug(`[TunnelVision] GENERATION_STOPPED — aborting in-flight sidecar fetches (duringRetrieval=${inRetrieval})`);
+            abortSidecarFetches();
+        });
     }
 
     // Post-generation sidecar writer (remember/update after model responds)
@@ -937,6 +973,8 @@ async function onGenerationStarted(type, opts, dryRun) {
     // Do NOT set _generationInProgress on dry runs: they never fire MESSAGE_RECEIVED or
     // GENERATION_ENDED to clear it, so it would stay true forever and block tool re-registration.
     if (dryRun) return;
+    // Drop any stale request from a turn that never reached the generate interceptor.
+    _stopRequestedDuringRetrieval = false;
 
     if (isPendingSlashCommandGeneration(type)) {
         _skipPreCommandGeneration = true;

--- a/llm-sidecar.js
+++ b/llm-sidecar.js
@@ -29,6 +29,29 @@ let _failureCount = 0;
 let _breakerOpen = false;
 let _breakerOpenedAt = 0;
 
+// ─── In-flight fetch tracking ────────────────────────────────────────
+// Only fetches started inside a retrieval scope are abortable. This keeps
+// ST's stop button from cancelling an in-flight sidecar *writer* (a memory
+// write), which would silently drop it. _fetchJson registers its controller
+// while the scope is open; abortSidecarFetches() aborts those on GENERATION_STOPPED.
+// ponytail: a depth counter, not a bool — safe if a scope ever nests
+const _activeFetches = new Set();
+let _retrievalScopeDepth = 0;
+
+/** Mark the start of retrieval network work; fetches started now are abortable. */
+export function beginRetrievalScope() { _retrievalScopeDepth++; }
+
+/** Mark the end of retrieval network work. Floors at 0 so it can't underflow. */
+export function endRetrievalScope() { _retrievalScopeDepth = Math.max(0, _retrievalScopeDepth - 1); }
+
+/** True while retrieval network work is in flight (ST is blocked on our handler). */
+export function isRetrievalScopeOpen() { return _retrievalScopeDepth > 0; }
+
+/** Abort every in-flight retrieval fetch. Called when the user stops generation. */
+export function abortSidecarFetches() {
+    for (const controller of _activeFetches) controller.abort();
+}
+
 export function resetCircuitBreaker() {
     _failureCount = 0;
     _breakerOpen = false;
@@ -129,18 +152,27 @@ export function isEmbeddingSupported() {
 
 async function _fetchJson(url, options, label) {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), SIDECAR_DEFAULT_TIMEOUT_MS);
+    let timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; controller.abort(); }, SIDECAR_DEFAULT_TIMEOUT_MS);
+    const tracked = _retrievalScopeDepth > 0;
+    if (tracked) _activeFetches.add(controller);
     let response;
     try {
         response = await fetch(url, { ...options, signal: controller.signal });
     } catch (error) {
-        // A bare AbortError reads as "signal is aborted without reason" — name the timeout.
         if (error?.name === 'AbortError') {
-            throw new Error(`${label} timed out after ${SIDECAR_DEFAULT_TIMEOUT_MS / 1000}s — the sidecar endpoint did not respond in time.`);
+            if (timedOut) {
+                // A bare AbortError reads as "signal is aborted without reason" — name the timeout.
+                throw new Error(`${label} timed out after ${SIDECAR_DEFAULT_TIMEOUT_MS / 1000}s — the sidecar endpoint did not respond in time.`);
+            }
+            // External abort (user pressed stop) — tag it so callers stay quiet
+            // and the circuit breaker doesn't count it as a failure.
+            throw Object.assign(new Error(`${label} cancelled`), { name: 'TVAbortError', cancelled: true });
         }
         throw error;
     } finally {
         clearTimeout(timer);
+        if (tracked) _activeFetches.delete(controller);
     }
     if (!response.ok) {
         let detail = '';
@@ -192,7 +224,8 @@ export async function sidecarGenerate({ prompt, systemPrompt }) {
         _recordSuccess();
         return typeof result === 'string' ? result.replace(THINK_BLOCK_RE, '').trim() : result;
     } catch (error) {
-        _recordFailure();
+        // A user-cancel is not an endpoint failure — don't push the breaker toward opening.
+        if (!error?.cancelled) _recordFailure();
         throw error;
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
     "requires": [],
     "optional": [],
     "js": "index.js",
+    "generate_interceptor": "TunnelVision_generateInterceptor",
     "css": "style.css",
     "author": "Coneja-Chibi",
     "version": "0.1.0",

--- a/sidecar-retrieval.js
+++ b/sidecar-retrieval.js
@@ -25,7 +25,7 @@ import {
 } from './tree-store.js';
 import { getReadableBooks } from './tool-registry.js';
 import { hasEvaluableConditions, separateConditions, mapSelectiveLogic, describeSelectiveLogic, CONDITION_DESCRIPTIONS, CONDITION_LABELS, rollKeywordProbability, formatCondition } from './conditions.js';
-import { isSidecarConfigured, isCircuitOpen, sidecarGenerate, getSidecarModelLabel } from './llm-sidecar.js';
+import { isSidecarConfigured, isCircuitOpen, sidecarGenerate, getSidecarModelLabel, beginRetrievalScope, endRetrievalScope } from './llm-sidecar.js';
 import { logSidecarRetrieval, logConditionalEvaluations, setSidecarActive } from './activity-feed.js';
 import { getKeywordTriggeredUids } from './index.js';
 import { applyBackgroundPromptAddendum, buildLanguageDirective } from './agent-utils.js';
@@ -497,7 +497,15 @@ export async function runSidecarRetrieval(type = null) {
         : [];
     const conditionalSection = buildConditionalSection(conditionalEntries);
 
+    // ST hides #mes_stop until after the GENERATION_STARTED await, so there is no
+    // cancel affordance during retrieval. Reveal ST's own button for the duration;
+    // clicking it runs stopGeneration() → GENERATION_STOPPED → abortSidecarFetches().
+    // ponytail: reuse ST's button, restore its prior state — no new UI, no ST import
+    const stopBtn = document.getElementById('mes_stop');
+    const revealedStopBtn = stopBtn && getComputedStyle(stopBtn).display === 'none';
+    if (revealedStopBtn) stopBtn.style.display = 'flex';
     setSidecarActive(true);
+    beginRetrievalScope();
     try {
         // Ask sidecar LLM to pick relevant nodes AND evaluate conditionals
         const prompt = buildRetrievalPrompt(treeOverview, recentChat, conditionalSection);
@@ -595,10 +603,16 @@ export async function runSidecarRetrieval(type = null) {
         console.log(`Total chars: ${capped.length} (~${Math.round(capped.length / 4)} tokens)`);
         console.groupEnd();
     } catch (error) {
-        console.error('[TunnelVision] Sidecar auto-retrieval failed:', error);
+        if (error?.cancelled) {
+            console.debug('[TunnelVision] Sidecar auto-retrieval cancelled — user stopped generation');
+        } else {
+            console.error('[TunnelVision] Sidecar auto-retrieval failed:', error);
+        }
         clearRetrievalPrompt(settings);
     } finally {
+        endRetrievalScope();
         setSidecarActive(false);
+        if (revealedStopBtn) stopBtn.style.display = 'none';
     }
 }
 

--- a/tests/llm-sidecar.test.js
+++ b/tests/llm-sidecar.test.js
@@ -440,6 +440,78 @@ describe('sidecarGenerate', () => {
     });
 });
 
+// ── abortSidecarFetches ──────────────────────────────────────────
+
+import { abortSidecarFetches, beginRetrievalScope, endRetrievalScope, isRetrievalScopeOpen } from '../llm-sidecar.js';
+
+describe('abortSidecarFetches', () => {
+    // A fetch that never resolves on its own — it only settles when its
+    // AbortSignal fires, mirroring a real request the user cancels mid-flight.
+    function abortableFetch() {
+        return vi.fn((url, opts) => new Promise((_, reject) => {
+            opts.signal.addEventListener('abort', () => {
+                const err = new Error('The operation was aborted');
+                err.name = 'AbortError';
+                reject(err);
+            });
+        }));
+    }
+
+    it('rejects an in-flight sidecarGenerate as cancelled, not timed out', async () => {
+        mockSidecarProfile = { ...validProfile };
+        vi.stubGlobal('fetch', abortableFetch());
+
+        beginRetrievalScope();
+        const pending = sidecarGenerate({ prompt: 'test' }); // registers synchronously
+        endRetrievalScope();
+        await Promise.resolve();
+        abortSidecarFetches();
+
+        await expect(pending).rejects.toMatchObject({ cancelled: true });
+        await expect(pending).rejects.not.toThrow(/timed out/);
+
+        vi.unstubAllGlobals();
+    });
+
+    it('does not count a cancel toward the circuit breaker', async () => {
+        mockSidecarProfile = { ...validProfile };
+        vi.stubGlobal('fetch', abortableFetch());
+
+        for (let i = 0; i < 3; i++) {
+            beginRetrievalScope();
+            const pending = sidecarGenerate({ prompt: 'test' });
+            endRetrievalScope();
+            await Promise.resolve();
+            abortSidecarFetches();
+            try { await pending; } catch { /* cancelled */ }
+        }
+
+        expect(isSidecarConfigured()).toBe(true);
+        expect(isCircuitOpen()).toBe(false);
+
+        vi.unstubAllGlobals();
+    });
+
+    it('does not abort a fetch started outside a retrieval scope (writer protection)', async () => {
+        mockSidecarProfile = { ...validProfile };
+        let aborted = false;
+        vi.stubGlobal('fetch', vi.fn((url, opts) => new Promise((resolve) => {
+            opts.signal.addEventListener('abort', () => { aborted = true; });
+            setTimeout(() => resolve({ ok: true, json: async () => ({ choices: [{ message: { content: 'ok' } }] }) }), 5);
+        })));
+
+        // No retrieval scope — this stands in for a sidecar writer call.
+        const pending = sidecarGenerate({ prompt: 'writer' });
+        await Promise.resolve();
+        abortSidecarFetches(); // must be a no-op for an unscoped fetch
+
+        await expect(pending).resolves.toBe('ok');
+        expect(aborted).toBe(false);
+
+        vi.unstubAllGlobals();
+    });
+});
+
 // ── getEmbeddingConfig ───────────────────────────────────────────
 
 describe('getEmbeddingConfig', () => {
@@ -739,5 +811,24 @@ describe('testEmbeddingConnectivity', () => {
         expect(result.message).toContain('Connection failed');
 
         vi.unstubAllGlobals();
+    });
+});
+
+// ── isRetrievalScopeOpen ─────────────────────────────────────────
+// Gates the "stop pressed during retrieval" flag in index.js: a stop that lands
+// while the scope is open must re-abort ST's freshly created abortController,
+// while a stop outside the scope (mid-stream, or during a sidecar writer) must not.
+describe('isRetrievalScopeOpen', () => {
+    it('is true only between begin and end, and survives nesting', () => {
+        expect(isRetrievalScopeOpen()).toBe(false);
+        beginRetrievalScope();
+        expect(isRetrievalScopeOpen()).toBe(true);
+        beginRetrievalScope();
+        endRetrievalScope();
+        expect(isRetrievalScopeOpen()).toBe(true);
+        endRetrievalScope();
+        expect(isRetrievalScopeOpen()).toBe(false);
+        endRetrievalScope(); // underflow guard
+        expect(isRetrievalScopeOpen()).toBe(false);
     });
 });

--- a/tests/sidecar-retrieval-cancel.test.js
+++ b/tests/sidecar-retrieval-cancel.test.js
@@ -1,0 +1,102 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../../st-context.js', () => ({ getContext: vi.fn() }));
+vi.mock('../../../../script.js', () => ({
+    setExtensionPrompt: vi.fn(),
+    extension_prompt_types: { IN_PROMPT: 0, IN_CHAT: 1, BEFORE_PROMPT: 2 },
+    extension_prompt_roles: { SYSTEM: 0, USER: 1, ASSISTANT: 2 },
+}));
+vi.mock('../../../world-info.js', () => ({ loadWorldInfo: vi.fn(async () => ({ entries: {} })) }));
+vi.mock('../tree-store.js', () => ({
+    getTree: vi.fn(() => ({ root: { id: 'root', label: 'Root', children: [{ id: 'n1', label: 'Node 1', children: [] }] } })),
+    findNodeById: vi.fn(() => null),
+    getAllEntryUids: vi.fn(() => []),
+    getSettings: vi.fn(() => ({ sidecarAutoRetrieval: true, sidecarContextMessages: 10, conditionalTriggersEnabled: false })),
+    isNativeInjectionBook: vi.fn(() => false),
+}));
+vi.mock('../tool-registry.js', () => ({ getReadableBooks: vi.fn(() => ['Book']) }));
+vi.mock('../conditions.js', () => ({
+    hasEvaluableConditions: vi.fn(() => false),
+    separateConditions: vi.fn(() => ({ conditions: [], keywords: [] })),
+    mapSelectiveLogic: vi.fn(() => 'AND_ANY'),
+    describeSelectiveLogic: vi.fn(() => ''),
+    rollKeywordProbability: vi.fn(() => true),
+    formatCondition: vi.fn(() => ''),
+    CONDITION_DESCRIPTIONS: {},
+    CONDITION_LABELS: {},
+}));
+vi.mock('../llm-sidecar.js', () => ({
+    isSidecarConfigured: vi.fn(() => true),
+    isCircuitOpen: vi.fn(() => false),
+    sidecarGenerate: vi.fn(async () => { throw Object.assign(new Error('Sidecar cancelled'), { name: 'TVAbortError', cancelled: true }); }),
+    getSidecarModelLabel: vi.fn(() => 'test-model'),
+    beginRetrievalScope: vi.fn(),
+    endRetrievalScope: vi.fn(),
+}));
+vi.mock('../activity-feed.js', () => ({
+    logSidecarRetrieval: vi.fn(),
+    logConditionalEvaluations: vi.fn(),
+    setSidecarActive: vi.fn(),
+}));
+vi.mock('../index.js', () => ({ getKeywordTriggeredUids: vi.fn(() => []) }));
+vi.mock('../agent-utils.js', () => ({
+    applyBackgroundPromptAddendum: vi.fn(s => s),
+    buildLanguageDirective: vi.fn(() => ''),
+}));
+
+const { getContext } = await import('../../../st-context.js');
+const { setExtensionPrompt } = await import('../../../../script.js');
+const { runSidecarRetrieval } = await import('../sidecar-retrieval.js');
+
+const CHAT = [
+    { is_user: true, is_system: false, mes: 'user question here' },
+    { is_user: false, is_system: false, mes: 'assistant reply here' },
+];
+
+describe('sidecar retrieval — cancellation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getContext.mockReturnValue({ chat: CHAT });
+        document.body.innerHTML = '<button id="mes_stop" class="mes_stop" style="display:none"></button>';
+    });
+
+    it('resolves without throwing when the sidecar call is cancelled', async () => {
+        await expect(runSidecarRetrieval()).resolves.toBeUndefined();
+    });
+
+    it('clears the retrieval prompt on cancel', async () => {
+        await runSidecarRetrieval();
+        // clearRetrievalPrompt sets the retrieval key to an empty string.
+        const clearedCall = setExtensionPrompt.mock.calls.find(
+            ([key, text]) => key === 'tunnelvision_sidecar_retrieval' && text === '',
+        );
+        expect(clearedCall).toBeTruthy();
+    });
+
+    it('logs the cancel via console.debug, not console.error', async () => {
+        const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        await runSidecarRetrieval();
+        expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('cancelled'));
+        expect(errorSpy).not.toHaveBeenCalled();
+        debugSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    it('reveals ST\'s stop button while the sidecar call runs', async () => {
+        const { sidecarGenerate } = await import('../llm-sidecar.js');
+        let displayDuringCall = null;
+        sidecarGenerate.mockImplementationOnce(async () => {
+            displayDuringCall = document.getElementById('mes_stop').style.display;
+            return 'NODES: none';
+        });
+        await runSidecarRetrieval();
+        expect(displayDuringCall).toBe('flex');
+    });
+
+    it('restores the stop button to hidden after retrieval', async () => {
+        await runSidecarRetrieval();
+        expect(document.getElementById('mes_stop').style.display).toBe('none');
+    });
+});

--- a/tests/sidecar-retrieval-swipe.test.js
+++ b/tests/sidecar-retrieval-swipe.test.js
@@ -1,3 +1,4 @@
+/* @vitest-environment jsdom */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Host context + heavy local deps mocked so we can exercise the retrieval
@@ -32,6 +33,8 @@ vi.mock('../llm-sidecar.js', () => ({
     isCircuitOpen: vi.fn(() => false),
     sidecarGenerate: vi.fn(async () => 'NODES: none'),
     getSidecarModelLabel: vi.fn(() => 'test-model'),
+    beginRetrievalScope: vi.fn(),
+    endRetrievalScope: vi.fn(),
 }));
 vi.mock('../activity-feed.js', () => ({
     logSidecarRetrieval: vi.fn(),


### PR DESCRIPTION
Sidecar auto-retrieval runs inside the `GENERATION_STARTED` await, which is before ST reveals `#mes_stop`. So for however long the retrieval takes there is no way to interrupt it — and if you do interrupt it, nothing stops the main model request that follows.

This does both halves.

### Cancelling the retrieval

`sidecar-retrieval.js` reveals ST's own stop button for the duration of the retrieval and restores its prior state afterwards, so there's no new UI to maintain. `GENERATION_STOPPED` then aborts the in-flight fetch.

The abort is deliberately scoped: only fetches started inside a retrieval scope get registered, so stopping a generation can never cancel an in-flight sidecar *writer* and silently drop a memory write. A cancel is also distinguished from a timeout, so aborting no longer counts toward the circuit breaker or logs as an error.

### Cancelling the reply

Aborting our own fetch isn't enough — `Generate()` is parked on the await we're holding and carries on to the main request as soon as we return.

Aborting ST's `abortController` doesn't work either, because `Generate` replaces it immediately after that await:

```js
await eventSource.emit(event_types.GENERATION_STARTED, ...);

// Don't recreate abort controller if signal is passed
if (!(abortController && signal)) {
    abortController = new AbortController();
}
```

I tried that first and confirmed it against a live instance: the stop fires, `stopGeneration()` runs, and ST carries straight on to `Running extension interceptors` and builds the request anyway. Throwing from the handler is inert too — `EventEmitter.emit` wraps every listener in `try/catch`.

So this registers a `generate_interceptor` and calls `abort(true)` when a stop landed during retrieval. `Generate` then returns at

```js
const aborted = await runGenerationInterceptors(coreChat, this_max_context, type);

if (aborted) {
    console.debug('Generation aborted by extension interceptors');
    unblockGeneration(type);
    return Promise.resolve();
}
```

before assembling any request — no fetch, no `AbortError`, no error toast. A toast tells the user the reply was deliberately cancelled, since otherwise it's indistinguishable from nothing having happened.

### Tests

New coverage for the scope gating and for an aborted `sidecarGenerate` rejecting as cancelled rather than timed out.

`upstream/main` currently fails 91 tests across 8 files (`activity-feed`, `embedding-cache`, `entry-manager`, `feed-helpers`, `shared-utils`, `smart-context`, `summary-hierarchy`, `tree-builder`) — all pre-existing and untouched here. This branch takes passing tests from 437 to 446 with no new failures.

Verified in a running SillyTavern, not just in tests.
