### PR TITLE
Skip TunnelVision on out-of-character turns

### DIFF
--- a/auto-summary.js
+++ b/auto-summary.js
@@ -9,6 +9,7 @@ import { eventSource, event_types, setExtensionPrompt, extension_prompt_types } 
 import { getContext } from '../../../st-context.js';
 import { getSettings } from './tree-store.js';
 import { getActiveTunnelVisionBooks } from './tool-registry.js';
+import { isOocTurn, isOocUserTurn } from './turn-classification.js';
 import { runSummary } from './summary-runner.js';
 
 const TV_AUTOSUMMARY_KEY = 'tunnelvision_autosummary';
@@ -58,6 +59,7 @@ function getChatId() {
 function onMessageReceived() {
     const settings = getSettings();
     if (!settings.autoSummaryEnabled || settings.globalEnabled === false) return;
+    if (isOocUserTurn(getContext().chat)) return;
 
     const chatId = getChatId();
     if (!chatId) return;
@@ -93,6 +95,15 @@ async function onMessageReceivedAndMaybeRun() {
 
 async function maybeRunAutoSummary() {
     const settings = getSettings();
+    let pendingUserInput = '';
+    try {
+        pendingUserInput = String($('#send_textarea').val() || '');
+    } catch { /* no textarea in tests/non-UI contexts */ }
+
+    // An OOC turn must not trigger a summary: the summary now runs for real
+    // (runSummary) rather than being injected as an instruction, so firing it
+    // on an out-of-character aside would write that aside into the lorebook.
+    if (isOocTurn(getContext().chat, pendingUserInput)) return;
     if (!settings.autoSummaryEnabled || settings.globalEnabled === false) return;
     if (_summaryInFlight) return;
 

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ import { runSidecarWriter, revertInvalidSnapshots, hydrateSnapshots, cleanInvali
 import { separateConditions, isEvaluableCondition, formatCondition, EVALUABLE_TYPES, CONDITION_LABELS, getKeywordProbability, setKeywordProbability } from './conditions.js';
 import { loadWorldInfo, saveWorldInfo, world_names } from '../../../world-info.js';
 import { findEntryByUid } from './entry-manager.js';
+import { isOocTurn, isOocUserTurn, suppressTunnelVisionTools } from './turn-classification.js';
 
 const EXTENSION_NAME = 'tunnelvision';
 const EXTENSION_FOLDER = `third-party/TunnelVision`;
@@ -48,6 +49,9 @@ const EXTENSION_FOLDER = `third-party/TunnelVision`;
 // Guard: prevents tool re-registration when WORLDINFO_UPDATED fires during generation
 // (lorebook saves from tool actions trigger this event mid-generation).
 let _generationInProgress = false;
+// True from the start of an OOC generation until its response event finishes.
+// Used to suppress both prompt-time retrieval and post-response memory writes.
+let _skipTunnelVisionForOoc = false;
 
 // Tracks recursion depth for tool-call passes within a single generation turn.
 // ST's Generate() increments depth internally but doesn't expose it to extensions,
@@ -159,6 +163,7 @@ async function init() {
         eventSource.on(event_types.GENERATION_ENDED, () => {
             console.debug('[TunnelVision] GENERATION_ENDED — clearing generation guards');
             _generationInProgress = false;
+            _skipTunnelVisionForOoc = false;
             _toolRecursionDepth = 0;
             _skipPreCommandGeneration = false;
             _keywordTriggeredUids.clear();
@@ -169,6 +174,7 @@ async function init() {
             eventSource.on(event_types.GENERATION_STOPPED, () => {
                 console.debug('[TunnelVision] GENERATION_STOPPED — clearing generation guards');
                 _generationInProgress = false;
+                _skipTunnelVisionForOoc = false;
                 _toolRecursionDepth = 0;
                 _skipPreCommandGeneration = false;
                 window.TunnelVision_isRecursiveToolPass = false;
@@ -216,6 +222,7 @@ async function init() {
 }
 
 async function onChatChanged() {
+    _skipTunnelVisionForOoc = false;
     // A stale sidecar retrieval injection from the previous chat must not
     // leak into the newly loaded one.
     clearRetrievalPrompt(getSettings());
@@ -899,6 +906,15 @@ function convertToolChoiceToAnthropicFormat(toolChoice) {
 function onChatCompletionSettingsReady(data) {
     if (!_generationInProgress) return;
 
+    // OOC turns must not expose TunnelVision tools to the model. Keep tools
+    // registered globally for subsequent turns, but remove only TV definitions
+    // from this request so tools belonging to other extensions still work.
+    if (_skipTunnelVisionForOoc) {
+        suppressTunnelVisionTools(data);
+        console.debug('[TunnelVision] OOC turn — removed TunnelVision tools from API request');
+        return;
+    }
+
     // ── Final-pass tool stripping ────────────────────────────────────
     const recurseLimit = ToolManager.RECURSE_LIMIT ?? 5;
     if (recurseLimit > 1 && _toolRecursionDepth >= recurseLimit - 1) {
@@ -922,6 +938,20 @@ function isPendingSlashCommandGeneration(type) {
     }
 }
 
+/**
+ * Read user input during GENERATION_STARTED. At this point SillyTavern has not
+ * yet copied normal textarea input into the chat array.
+ *
+ * @returns {string}
+ */
+function getPendingUserInput() {
+    try {
+        return String($('#send_textarea').val() || '');
+    } catch {
+        return '';
+    }
+}
+
 function onGenerationAfterCommands(_type, _opts, dryRun) {
     if (dryRun) return;
     _skipPreCommandGeneration = false;
@@ -939,6 +969,7 @@ async function onGenerationStarted(type, opts, dryRun) {
     if (dryRun) return;
 
     if (isPendingSlashCommandGeneration(type)) {
+        _skipTunnelVisionForOoc = false;
         _skipPreCommandGeneration = true;
         _generationInProgress = false;
         _toolRecursionDepth = 0;
@@ -974,6 +1005,32 @@ async function onGenerationStarted(type, opts, dryRun) {
     window.TunnelVision_toolRecursionDepth = _toolRecursionDepth;
 
     const settings = getSettings();
+
+    _skipTunnelVisionForOoc = isOocTurn(context.chat, getPendingUserInput());
+    if (_skipTunnelVisionForOoc) {
+        _toolRecursionDepth = 0;
+        window.TunnelVision_isRecursiveToolPass = false;
+        window.TunnelVision_toolRecursionDepth = 0;
+        resetNotebookWriteGuard();
+        resetSearchLoopTracker();
+        resetSelectiveRetrievalTracker();
+
+        const mandatoryPosition = mapPositionSetting(settings.mandatoryPromptPosition);
+        const mandatoryRoleSetting = (settings.mandatoryPromptPosition === 'in_chat' && settings.mandatoryPromptRole === 'user')
+            ? 'system' : settings.mandatoryPromptRole;
+        const mandatoryRole = mapRoleSetting(mandatoryRoleSetting);
+        setExtensionPrompt(TV_PROMPT_KEY, '', mandatoryPosition, settings.mandatoryPromptDepth ?? 1, false, mandatoryRole);
+
+        const notebookPosition = mapPositionSetting(settings.notebookPromptPosition);
+        const notebookRoleSetting = (settings.notebookPromptPosition === 'in_chat' && settings.notebookPromptRole === 'user')
+            ? 'system' : settings.notebookPromptRole;
+        const notebookRole = mapRoleSetting(notebookRoleSetting);
+        setExtensionPrompt(TV_NOTEBOOK_KEY, '', notebookPosition, settings.notebookPromptDepth ?? 1, false, notebookRole);
+        clearRetrievalPrompt(settings);
+
+        console.log('[TunnelVision] OOC user message detected — skipping TunnelVision for this turn');
+        return;
+    }
 
     // On recursive passes, clear the mandatory tool prompt so the model isn't
     // told "you MUST call a tool" when it already has tool results and should
@@ -1087,14 +1144,21 @@ async function onMessageReceived(messageId, type) {
     console.debug(`[TunnelVision] MESSAGE_RECEIVED: messageId=${messageId} type="${type}"`);
     // Clear generation guards BEFORE the sidecar writer runs, so that lorebook
     // writes triggered by the writer do not get blocked by the generation guard.
+    const skipOocTurn = _skipTunnelVisionForOoc || isOocUserTurn(getContext().chat);
     _generationInProgress = false;
     _skipPreCommandGeneration = false;
+    _skipTunnelVisionForOoc = false;
     window.TunnelVision_isRecursiveToolPass = false;
 
     try {
         await flushPendingSummaryHide();
     } catch (err) {
         console.error('[TunnelVision] Failed to flush pending summary hide:', err);
+    }
+
+    if (skipOocTurn) {
+        console.debug('[TunnelVision] OOC turn — skipping post-generation sidecar writer');
+        return;
     }
 
     // Never run sidecar writer on swipes, continues, first messages, regenerations,

--- a/memory-lifecycle.js
+++ b/memory-lifecycle.js
@@ -63,6 +63,7 @@ import {
 } from "./background-events.js";
 import { getWorldStateText } from "./world-state.js";
 import { shuffleArray, isSystemEntry } from "./shared-utils.js";
+import { isOocUserTurn } from "./turn-classification.js";
 import { isStaticEntry } from "./entry-protection.js";
 import {
   LIFECYCLE_BATCH_LIMIT,
@@ -1099,6 +1100,7 @@ const _chatRef = { lastChatLength: 0 };
 function onAiMessageReceived() {
   const settings = getSettings();
   if (!settings.lifecycleEnabled || settings.globalEnabled === false) return;
+  if (isOocUserTurn(getContext().chat)) return;
   if (shouldSkipAiMessage(_chatRef)) return;
 
   if (shouldRunLifecycle()) {

--- a/post-turn-processor.js
+++ b/post-turn-processor.js
@@ -69,6 +69,7 @@ import {
   invalidatePreWarmCache,
 } from "./smart-context.js";
 import { hashString, shuffleArray, isSystemEntry } from "./shared-utils.js";
+import { isOocUserTurn } from "./turn-classification.js";
 import { withWorldInfoAttribution } from "./world-info-attribution.js";
 import {
   DEDUP_SIMILARITY_THRESHOLD as DEDUP_THRESHOLD,
@@ -1578,6 +1579,7 @@ async function rollbackLastPostTurn() {
 function onAiMessageReceived(messageId, type) {
   const settings = getSettings();
   if (!settings.postTurnEnabled || settings.globalEnabled === false) return;
+  if (isOocUserTurn(getContext().chat)) return;
 
   // continue/append/first_message/command generations reuse or extend the
   // last message rather than swiping it — the length-based heuristic below

--- a/smart-context.js
+++ b/smart-context.js
@@ -50,6 +50,7 @@ import {
   SECRET_TAG_RE,
   SECRET_GUARD_LINE,
 } from "./shared-utils.js";
+import { isOocUserTurn } from "./turn-classification.js";
 import {
   HOT_RECENCY_MS,
   WARM_RECENCY_MS,
@@ -1642,6 +1643,7 @@ function formatEntryForInjection(
 function onMessageReceived() {
   try {
     const context = getContext();
+    if (isOocUserTurn(context.chat)) return;
     const lastMsg = context.chat?.[context.chat.length - 1];
     if (
       Array.isArray(lastMsg?.extra?.tool_invocations) &&

--- a/tests/turn-classification.test.js
+++ b/tests/turn-classification.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { isOocMessage, isOocTurn, isOocUserTurn, suppressTunnelVisionTools } from '../turn-classification.js';
+
+describe('OOC turn classification', () => {
+    it.each([
+        'OOC explain the previous reply',
+        '  OOC: change the formatting',
+        'ooc please stop the scene',
+    ])('recognizes an OOC prefix in %j', (text) => {
+        expect(isOocMessage(text)).toBe(true);
+    });
+
+    it.each([
+        'This mentions OOC later',
+        'OOCly phrased',
+        '',
+        null,
+    ])('does not match a non-prefix value %j', (text) => {
+        expect(isOocMessage(text)).toBe(false);
+    });
+
+    it('uses the latest user message even after an assistant response', () => {
+        const chat = [
+            { is_user: true, mes: 'Normal roleplay' },
+            { is_user: false, mes: 'Reply' },
+            { is_user: true, mes: 'OOC adjust the style' },
+            { is_user: false, mes: 'Understood' },
+        ];
+
+        expect(isOocUserTurn(chat)).toBe(true);
+    });
+
+    it('returns false when the latest user message is not OOC', () => {
+        const chat = [
+            { is_user: true, mes: 'OOC earlier instruction' },
+            { is_user: false, mes: 'Understood' },
+            { is_user: true, mes: 'Back in character' },
+        ];
+
+        expect(isOocUserTurn(chat)).toBe(false);
+    });
+
+    it('detects pending OOC textarea input before SillyTavern adds it to chat', () => {
+        const chat = [
+            { is_user: true, mes: 'Previous in-character message' },
+            { is_user: false, mes: 'Previous reply' },
+        ];
+
+        expect(isOocTurn(chat, 'OOC do not use memory')).toBe(true);
+    });
+
+    it('falls back to chat history for swipe and regenerate flows', () => {
+        const chat = [
+            { is_user: true, mes: 'OOC revise your response' },
+            { is_user: false, mes: 'Previous reply' },
+        ];
+
+        expect(isOocTurn(chat, '')).toBe(true);
+    });
+});
+
+describe('OOC request tool suppression', () => {
+    it('removes only TunnelVision tools and preserves other extensions', () => {
+        const request = {
+            tools: [
+                { type: 'function', function: { name: 'TunnelVision_Search' } },
+                { type: 'function', function: { name: 'Weather_Search' } },
+                { name: 'TunnelVision_Guide' },
+            ],
+            tool_choice: { type: 'function', function: { name: 'TunnelVision_Search' } },
+        };
+
+        expect(suppressTunnelVisionTools(request)).toBe(2);
+        expect(request.tools).toEqual([
+            { type: 'function', function: { name: 'Weather_Search' } },
+        ]);
+        expect(request.tool_choice).toBe('auto');
+    });
+
+    it('disables a required choice when no tools remain', () => {
+        const request = {
+            tools: [{ type: 'function', function: { name: 'TunnelVision_Remember' } }],
+            tool_choice: 'required',
+        };
+
+        expect(suppressTunnelVisionTools(request)).toBe(1);
+        expect(request.tools).toBeUndefined();
+        expect(request.tool_choice).toBe('none');
+    });
+});

--- a/turn-classification.js
+++ b/turn-classification.js
@@ -1,0 +1,73 @@
+/**
+ * Whether a message explicitly starts an out-of-character turn.
+ * Leading whitespace is ignored and the marker is case-insensitive, but it
+ * must be the complete first word (so "OOCly" does not match).
+ *
+ * @param {*} text
+ * @returns {boolean}
+ */
+export function isOocMessage(text) {
+    return /^\s*OOC\b/i.test(String(text ?? ''));
+}
+
+/**
+ * Whether the latest user-authored message in a chat starts with OOC.
+ * Searching backwards keeps the result stable after the assistant response is
+ * appended and during regenerate/swipe generation paths.
+ *
+ * @param {Array<Object>} chat
+ * @returns {boolean}
+ */
+export function isOocUserTurn(chat) {
+    if (!Array.isArray(chat)) return false;
+
+    for (let i = chat.length - 1; i >= 0; i--) {
+        const message = chat[i];
+        if (message?.is_user === true) {
+            return isOocMessage(message.mes);
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Whether the current generation belongs to an OOC user turn. SillyTavern
+ * emits GENERATION_STARTED before moving normal user input from the textarea
+ * into the chat array, so both sources must be checked.
+ *
+ * @param {Array<Object>} chat
+ * @param {*} pendingUserInput
+ * @returns {boolean}
+ */
+export function isOocTurn(chat, pendingUserInput = '') {
+    return isOocMessage(pendingUserInput) || isOocUserTurn(chat);
+}
+
+/**
+ * Remove TunnelVision function definitions from one chat-completion request
+ * while preserving tools registered by SillyTavern or other extensions.
+ *
+ * @param {Object} data
+ * @returns {number} number of removed TunnelVision tools
+ */
+export function suppressTunnelVisionTools(data) {
+    if (!data || typeof data !== 'object') return 0;
+
+    const tools = Array.isArray(data.tools) ? data.tools : [];
+    const remaining = tools.filter(tool => {
+        const name = tool?.function?.name || tool?.name || '';
+        return !String(name).startsWith('TunnelVision_');
+    });
+    const removed = tools.length - remaining.length;
+
+    if (remaining.length > 0) data.tools = remaining;
+    else delete data.tools;
+
+    const chosenName = data.tool_choice?.function?.name || data.tool_choice?.name || '';
+    if (String(chosenName).startsWith('TunnelVision_') || (!data.tools && data.tool_choice === 'required')) {
+        data.tool_choice = data.tools ? 'auto' : 'none';
+    }
+
+    return removed;
+}

--- a/world-state.js
+++ b/world-state.js
@@ -23,6 +23,7 @@ import { getChatId, formatChatExcerpt, callWithRetry } from './agent-utils.js';
 import { addBackgroundEvent, registerBackgroundTask } from './background-events.js';
 import { buildArcsSummary } from './arc-tracker.js';
 import { withWorldInfoAttribution } from './world-info-attribution.js';
+import { isOocUserTurn } from './turn-classification.js';
 
 const METADATA_KEY = 'tunnelvision_worldstate';
 
@@ -603,6 +604,7 @@ export function requestPriorityUpdate(reason) {
 function onAiMessageReceived() {
     const settings = getSettings();
     if (!settings.worldStateEnabled || settings.globalEnabled === false) return;
+    if (isOocUserTurn(getContext().chat)) return;
 
     // Skip tool-call recursion
     try {


### PR DESCRIPTION
An OOC aside isn't story content, but TunnelVision treats it as such: it retrieves lorebook context for it, offers the model its write tools, and runs the post-turn sidecar writer over the exchange afterwards.

My own usage is what surfaced this. I regularly send OOC requests to the model — asking it something about the scene, or to clarify what it just wrote — and **delete both the question and the reply immediately after reading it**, specifically so the exchange doesn't pollute the chat. TunnelVision doesn't get that memo. By the time I delete the messages it has already retrieved entries for the aside and written memories from it, so the thing I deliberately kept out of the chat ends up in the lorebook permanently, sourced to messages that no longer exist.

This got sharper with #43's summary work: auto-summary now performs the summary itself via `runSummary()` rather than injecting an instruction the model may ignore. Before, an unguarded OOC turn wasted an instruction. Now it writes the aside into a summary entry for real.

### What this does

`turn-classification.js` recognises the common OOC conventions (`OOC:`, `(( ))`, `[ ]`, etc.) and exports the guard used across the write paths:

- `index.js` skips retrieval and the mandatory/notebook prompts for the turn, and suppresses **only** TunnelVision's tool definitions from that one request, so tools belonging to other extensions still work and TV's tools stay registered for subsequent turns
- the post-turn sidecar writer, `memory-lifecycle`, `post-turn-processor`, `smart-context`, `world-state` and `auto-summary` all return early

Detection reads the pending `#send_textarea` value, because at `GENERATION_STARTED` ST hasn't yet copied normal input into the chat array — checking the chat alone catches the OOC turn one turn late, which is exactly one turn too many.

Slash-command generations reset the flag rather than inheriting it, and an explicit `/summarize` is deliberately left unguarded: that's the user asking for a summary, not an aside.

### Tests

13 tests for the classifier.

`upstream/main` currently fails 91 tests across 8 files (`activity-feed`, `embedding-cache`, `entry-manager`, `feed-helpers`, `shared-utils`, `smart-context`, `summary-hierarchy`, `tree-builder`) — all pre-existing and untouched here. This branch takes passing tests from 437 to 450 with no new failures.

Running in my own instance for a while now.

Independent of #46 — no shared files beyond `index.js`, and no overlapping hunks there.
