### PR TITLE
Let OOC turns read the lorebook, but not write to it

### DIFF
--- a/auto-summary.js
+++ b/auto-summary.js
@@ -9,6 +9,7 @@ import { eventSource, event_types, setExtensionPrompt, extension_prompt_types } 
 import { getContext } from '../../../st-context.js';
 import { getSettings } from './tree-store.js';
 import { getActiveTunnelVisionBooks } from './tool-registry.js';
+import { isOocTurn, isOocUserTurn } from './turn-classification.js';
 import { runSummary } from './summary-runner.js';
 
 const TV_AUTOSUMMARY_KEY = 'tunnelvision_autosummary';
@@ -58,6 +59,7 @@ function getChatId() {
 function onMessageReceived() {
     const settings = getSettings();
     if (!settings.autoSummaryEnabled || settings.globalEnabled === false) return;
+    if (isOocUserTurn(getContext().chat)) return;
 
     const chatId = getChatId();
     if (!chatId) return;
@@ -93,6 +95,15 @@ async function onMessageReceivedAndMaybeRun() {
 
 async function maybeRunAutoSummary() {
     const settings = getSettings();
+    let pendingUserInput = '';
+    try {
+        pendingUserInput = String($('#send_textarea').val() || '');
+    } catch { /* no textarea in tests/non-UI contexts */ }
+
+    // An OOC turn must not trigger a summary: the summary now runs for real
+    // (runSummary) rather than being injected as an instruction, so firing it
+    // on an out-of-character aside would write that aside into the lorebook.
+    if (isOocTurn(getContext().chat, pendingUserInput)) return;
     if (!settings.autoSummaryEnabled || settings.globalEnabled === false) return;
     if (_summaryInFlight) return;
 

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ import { runSidecarWriter, revertInvalidSnapshots, hydrateSnapshots, cleanInvali
 import { separateConditions, isEvaluableCondition, formatCondition, EVALUABLE_TYPES, CONDITION_LABELS, getKeywordProbability, setKeywordProbability } from './conditions.js';
 import { loadWorldInfo, saveWorldInfo, world_names } from '../../../world-info.js';
 import { findEntryByUid } from './entry-manager.js';
+import { isOocTurn, isOocUserTurn, suppressTunnelVisionWriteTools } from './turn-classification.js';
 
 const EXTENSION_NAME = 'tunnelvision';
 const EXTENSION_FOLDER = `third-party/TunnelVision`;
@@ -48,6 +49,9 @@ const EXTENSION_FOLDER = `third-party/TunnelVision`;
 // Guard: prevents tool re-registration when WORLDINFO_UPDATED fires during generation
 // (lorebook saves from tool actions trigger this event mid-generation).
 let _generationInProgress = false;
+// True from the start of an OOC generation until its response event finishes.
+// Retrieval still runs; this suppresses only the write paths.
+let _skipTunnelVisionForOoc = false;
 
 // Tracks recursion depth for tool-call passes within a single generation turn.
 // ST's Generate() increments depth internally but doesn't expose it to extensions,
@@ -159,6 +163,7 @@ async function init() {
         eventSource.on(event_types.GENERATION_ENDED, () => {
             console.debug('[TunnelVision] GENERATION_ENDED — clearing generation guards');
             _generationInProgress = false;
+            _skipTunnelVisionForOoc = false;
             _toolRecursionDepth = 0;
             _skipPreCommandGeneration = false;
             _keywordTriggeredUids.clear();
@@ -169,6 +174,7 @@ async function init() {
             eventSource.on(event_types.GENERATION_STOPPED, () => {
                 console.debug('[TunnelVision] GENERATION_STOPPED — clearing generation guards');
                 _generationInProgress = false;
+                _skipTunnelVisionForOoc = false;
                 _toolRecursionDepth = 0;
                 _skipPreCommandGeneration = false;
                 window.TunnelVision_isRecursiveToolPass = false;
@@ -216,6 +222,7 @@ async function init() {
 }
 
 async function onChatChanged() {
+    _skipTunnelVisionForOoc = false;
     // A stale sidecar retrieval injection from the previous chat must not
     // leak into the newly loaded one.
     clearRetrievalPrompt(getSettings());
@@ -899,6 +906,16 @@ function convertToolChoiceToAnthropicFormat(toolChoice) {
 function onChatCompletionSettingsReady(data) {
     if (!_generationInProgress) return;
 
+    // An OOC turn still gets retrieved lorebook context, but must not be able to
+    // write. Strip TunnelVision's writing tools from this one request, keeping
+    // the read-only ones and any tool belonging to another extension. Tools stay
+    // registered globally so the next in-character turn is unaffected.
+    if (_skipTunnelVisionForOoc) {
+        const removed = suppressTunnelVisionWriteTools(data);
+        console.debug(`[TunnelVision] OOC turn — removed ${removed} TunnelVision write tool(s) from API request`);
+        return;
+    }
+
     // ── Final-pass tool stripping ────────────────────────────────────
     const recurseLimit = ToolManager.RECURSE_LIMIT ?? 5;
     if (recurseLimit > 1 && _toolRecursionDepth >= recurseLimit - 1) {
@@ -922,6 +939,20 @@ function isPendingSlashCommandGeneration(type) {
     }
 }
 
+/**
+ * Read user input during GENERATION_STARTED. At this point SillyTavern has not
+ * yet copied normal textarea input into the chat array.
+ *
+ * @returns {string}
+ */
+function getPendingUserInput() {
+    try {
+        return String($('#send_textarea').val() || '');
+    } catch {
+        return '';
+    }
+}
+
 function onGenerationAfterCommands(_type, _opts, dryRun) {
     if (dryRun) return;
     _skipPreCommandGeneration = false;
@@ -939,6 +970,7 @@ async function onGenerationStarted(type, opts, dryRun) {
     if (dryRun) return;
 
     if (isPendingSlashCommandGeneration(type)) {
+        _skipTunnelVisionForOoc = false;
         _skipPreCommandGeneration = true;
         _generationInProgress = false;
         _toolRecursionDepth = 0;
@@ -974,6 +1006,16 @@ async function onGenerationStarted(type, opts, dryRun) {
     window.TunnelVision_toolRecursionDepth = _toolRecursionDepth;
 
     const settings = getSettings();
+
+    // An OOC aside is a question *about* the story, so retrieval still runs and
+    // the model still gets its lorebook context. Only writing is suppressed:
+    // the write tools are stripped from the request (onChatCompletionSettingsReady),
+    // the "you MUST call a tool" instruction is withheld below, and every
+    // post-turn writer returns early on MESSAGE_RECEIVED.
+    _skipTunnelVisionForOoc = isOocTurn(context.chat, getPendingUserInput());
+    if (_skipTunnelVisionForOoc) {
+        console.log('[TunnelVision] OOC turn — retrieval still runs, writes suppressed');
+    }
 
     // On recursive passes, clear the mandatory tool prompt so the model isn't
     // told "you MUST call a tool" when it already has tool results and should
@@ -1028,6 +1070,7 @@ async function onGenerationStarted(type, opts, dryRun) {
 
     if (
         settings.globalEnabled !== false
+        && !_skipTunnelVisionForOoc
         && settings.mandatoryTools
         && ToolManager.canPerformToolCalls(type)
         && runtimeState?.activeBooks?.length > 0
@@ -1087,14 +1130,21 @@ async function onMessageReceived(messageId, type) {
     console.debug(`[TunnelVision] MESSAGE_RECEIVED: messageId=${messageId} type="${type}"`);
     // Clear generation guards BEFORE the sidecar writer runs, so that lorebook
     // writes triggered by the writer do not get blocked by the generation guard.
+    const skipOocTurn = _skipTunnelVisionForOoc || isOocUserTurn(getContext().chat);
     _generationInProgress = false;
     _skipPreCommandGeneration = false;
+    _skipTunnelVisionForOoc = false;
     window.TunnelVision_isRecursiveToolPass = false;
 
     try {
         await flushPendingSummaryHide();
     } catch (err) {
         console.error('[TunnelVision] Failed to flush pending summary hide:', err);
+    }
+
+    if (skipOocTurn) {
+        console.debug('[TunnelVision] OOC turn — skipping post-generation sidecar writer');
+        return;
     }
 
     // Never run sidecar writer on swipes, continues, first messages, regenerations,

--- a/memory-lifecycle.js
+++ b/memory-lifecycle.js
@@ -63,6 +63,7 @@ import {
 } from "./background-events.js";
 import { getWorldStateText } from "./world-state.js";
 import { shuffleArray, isSystemEntry } from "./shared-utils.js";
+import { isOocUserTurn } from "./turn-classification.js";
 import { isStaticEntry } from "./entry-protection.js";
 import {
   LIFECYCLE_BATCH_LIMIT,
@@ -1099,6 +1100,7 @@ const _chatRef = { lastChatLength: 0 };
 function onAiMessageReceived() {
   const settings = getSettings();
   if (!settings.lifecycleEnabled || settings.globalEnabled === false) return;
+  if (isOocUserTurn(getContext().chat)) return;
   if (shouldSkipAiMessage(_chatRef)) return;
 
   if (shouldRunLifecycle()) {

--- a/post-turn-processor.js
+++ b/post-turn-processor.js
@@ -69,6 +69,7 @@ import {
   invalidatePreWarmCache,
 } from "./smart-context.js";
 import { hashString, shuffleArray, isSystemEntry } from "./shared-utils.js";
+import { isOocUserTurn } from "./turn-classification.js";
 import { withWorldInfoAttribution } from "./world-info-attribution.js";
 import {
   DEDUP_SIMILARITY_THRESHOLD as DEDUP_THRESHOLD,
@@ -1578,6 +1579,7 @@ async function rollbackLastPostTurn() {
 function onAiMessageReceived(messageId, type) {
   const settings = getSettings();
   if (!settings.postTurnEnabled || settings.globalEnabled === false) return;
+  if (isOocUserTurn(getContext().chat)) return;
 
   // continue/append/first_message/command generations reuse or extend the
   // last message rather than swiping it — the length-based heuristic below

--- a/smart-context.js
+++ b/smart-context.js
@@ -50,6 +50,7 @@ import {
   SECRET_TAG_RE,
   SECRET_GUARD_LINE,
 } from "./shared-utils.js";
+import { isOocUserTurn } from "./turn-classification.js";
 import {
   HOT_RECENCY_MS,
   WARM_RECENCY_MS,
@@ -1642,6 +1643,7 @@ function formatEntryForInjection(
 function onMessageReceived() {
   try {
     const context = getContext();
+    if (isOocUserTurn(context.chat)) return;
     const lastMsg = context.chat?.[context.chat.length - 1];
     if (
       Array.isArray(lastMsg?.extra?.tool_invocations) &&

--- a/tests/turn-classification.test.js
+++ b/tests/turn-classification.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { isOocMessage, isOocTurn, isOocUserTurn, suppressTunnelVisionWriteTools } from '../turn-classification.js';
+
+describe('OOC turn classification', () => {
+    it.each([
+        'OOC explain the previous reply',
+        '  OOC: change the formatting',
+        'ooc please stop the scene',
+    ])('recognizes a bare OOC prefix in %j', (text) => {
+        expect(isOocMessage(text)).toBe(true);
+    });
+
+    it.each([
+        '(OOC: how old is she again?)',
+        '((OOC: how old is she again?))',
+        '[OOC: how old is she again?]',
+        '<OOC> how old is she again?',
+        '**OOC** how old is she again?',
+        '  ((ooc: lowercase and indented))',
+    ])('recognizes a wrapped OOC marker in %j', (text) => {
+        expect(isOocMessage(text)).toBe(true);
+    });
+
+    it.each([
+        'This mentions OOC later',
+        'OOCly phrased',
+        '',
+        null,
+    ])('does not match a non-prefix value %j', (text) => {
+        expect(isOocMessage(text)).toBe(false);
+    });
+
+    // Bare brackets are action beats and sound effects, not OOC. Treating them
+    // as OOC would suppress memory writes on ordinary roleplay.
+    it.each([
+        '[ she leaves the room ]',
+        '(( a door slams ))',
+        '*he shrugs*',
+        '{{OOC}} macro syntax, not a marker',
+    ])('does not treat unmarked brackets or emphasis as OOC: %j', (text) => {
+        expect(isOocMessage(text)).toBe(false);
+    });
+
+    it('uses the latest user message even after an assistant response', () => {
+        const chat = [
+            { is_user: true, mes: 'Normal roleplay' },
+            { is_user: false, mes: 'Reply' },
+            { is_user: true, mes: 'OOC adjust the style' },
+            { is_user: false, mes: 'Understood' },
+        ];
+
+        expect(isOocUserTurn(chat)).toBe(true);
+    });
+
+    it('returns false when the latest user message is not OOC', () => {
+        const chat = [
+            { is_user: true, mes: 'OOC earlier instruction' },
+            { is_user: false, mes: 'Understood' },
+            { is_user: true, mes: 'Back in character' },
+        ];
+
+        expect(isOocUserTurn(chat)).toBe(false);
+    });
+
+    it('detects pending OOC textarea input before SillyTavern adds it to chat', () => {
+        const chat = [
+            { is_user: true, mes: 'Previous in-character message' },
+            { is_user: false, mes: 'Previous reply' },
+        ];
+
+        expect(isOocTurn(chat, 'OOC do not use memory')).toBe(true);
+    });
+
+    it('falls back to chat history for swipe and regenerate flows', () => {
+        const chat = [
+            { is_user: true, mes: 'OOC revise your response' },
+            { is_user: false, mes: 'Previous reply' },
+        ];
+
+        expect(isOocTurn(chat, '')).toBe(true);
+    });
+});
+
+describe('OOC request tool suppression', () => {
+    it('keeps read-only Search, drops TunnelVision writers, preserves other extensions', () => {
+        const request = {
+            tools: [
+                { type: 'function', function: { name: 'TunnelVision_Search' } },
+                { type: 'function', function: { name: 'Weather_Search' } },
+                { name: 'TunnelVision_Guide' },
+                { type: 'function', function: { name: 'TunnelVision_Remember' } },
+            ],
+        };
+
+        expect(suppressTunnelVisionWriteTools(request)).toBe(2);
+        expect(request.tools).toEqual([
+            { type: 'function', function: { name: 'TunnelVision_Search' } },
+            { type: 'function', function: { name: 'Weather_Search' } },
+        ]);
+    });
+
+    it('leaves a tool_choice that survived the strip alone', () => {
+        const request = {
+            tools: [{ type: 'function', function: { name: 'TunnelVision_Search' } }],
+            tool_choice: { type: 'function', function: { name: 'TunnelVision_Search' } },
+        };
+
+        expect(suppressTunnelVisionWriteTools(request)).toBe(0);
+        expect(request.tool_choice).toEqual({ type: 'function', function: { name: 'TunnelVision_Search' } });
+    });
+
+    it('falls back to auto when the chosen tool was a writer that got removed', () => {
+        const request = {
+            tools: [
+                { type: 'function', function: { name: 'TunnelVision_Remember' } },
+                { type: 'function', function: { name: 'Weather_Search' } },
+            ],
+            tool_choice: { type: 'function', function: { name: 'TunnelVision_Remember' } },
+        };
+
+        expect(suppressTunnelVisionWriteTools(request)).toBe(1);
+        expect(request.tool_choice).toBe('auto');
+    });
+
+    it('disables a required choice when no tools remain', () => {
+        const request = {
+            tools: [{ type: 'function', function: { name: 'TunnelVision_Remember' } }],
+            tool_choice: 'required',
+        };
+
+        expect(suppressTunnelVisionWriteTools(request)).toBe(1);
+        expect(request.tools).toBeUndefined();
+        expect(request.tool_choice).toBe('none');
+    });
+});

--- a/turn-classification.js
+++ b/turn-classification.js
@@ -1,0 +1,89 @@
+/**
+ * Whether a message explicitly starts an out-of-character turn.
+ *
+ * The marker is case-insensitive and may be wrapped in the usual chat
+ * decorations — `(OOC: ...)`, `((OOC: ...))`, `[OOC: ...]`, `<OOC> ...`,
+ * `**OOC** ...` — so leading brackets and emphasis are skipped.
+ *
+ * It must still be the complete first word: "OOCly" does not match, and
+ * neither does a bare `[ ... ]` or `(( ... ))` with no OOC marker inside.
+ * Those brackets are widely used for action beats and sound effects mid-scene,
+ * so treating them as OOC would suppress memory writes on ordinary roleplay.
+ *
+ * @param {*} text
+ * @returns {boolean}
+ */
+export function isOocMessage(text) {
+    return /^[\s(\[<*]*OOC\b/i.test(String(text ?? ''));
+}
+
+/**
+ * Whether the latest user-authored message in a chat starts with OOC.
+ * Searching backwards keeps the result stable after the assistant response is
+ * appended and during regenerate/swipe generation paths.
+ *
+ * @param {Array<Object>} chat
+ * @returns {boolean}
+ */
+export function isOocUserTurn(chat) {
+    if (!Array.isArray(chat)) return false;
+
+    for (let i = chat.length - 1; i >= 0; i--) {
+        const message = chat[i];
+        if (message?.is_user === true) {
+            return isOocMessage(message.mes);
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Whether the current generation belongs to an OOC user turn. SillyTavern
+ * emits GENERATION_STARTED before moving normal user input from the textarea
+ * into the chat array, so both sources must be checked.
+ *
+ * @param {Array<Object>} chat
+ * @param {*} pendingUserInput
+ * @returns {boolean}
+ */
+export function isOocTurn(chat, pendingUserInput = '') {
+    return isOocMessage(pendingUserInput) || isOocUserTurn(chat);
+}
+
+/**
+ * TunnelVision_Search only reads the lorebook, so it stays available on an OOC
+ * turn — answering "how old is she again?" is exactly what it is for. Every
+ * other TunnelVision tool mutates stored memory.
+ */
+const OOC_SAFE_TOOLS = new Set(['TunnelVision_Search']);
+
+/**
+ * Remove TunnelVision's *writing* function definitions from one chat-completion
+ * request, leaving the read-only ones plus any tool registered by SillyTavern or
+ * another extension.
+ *
+ * @param {Object} data
+ * @returns {number} number of removed TunnelVision tools
+ */
+export function suppressTunnelVisionWriteTools(data) {
+    if (!data || typeof data !== 'object') return 0;
+
+    const tools = Array.isArray(data.tools) ? data.tools : [];
+    const remaining = tools.filter(tool => {
+        const name = String(tool?.function?.name || tool?.name || '');
+        return !name.startsWith('TunnelVision_') || OOC_SAFE_TOOLS.has(name);
+    });
+    const removed = tools.length - remaining.length;
+
+    if (remaining.length > 0) data.tools = remaining;
+    else delete data.tools;
+
+    const chosenName = String(data.tool_choice?.function?.name || data.tool_choice?.name || '');
+    const chosenRemoved = chosenName.startsWith('TunnelVision_') && !OOC_SAFE_TOOLS.has(chosenName);
+    if (chosenRemoved || (!data.tools && data.tool_choice === 'required')) {
+        data.tool_choice = data.tools ? 'auto' : 'none';
+    }
+
+    return removed;
+}

--- a/world-state.js
+++ b/world-state.js
@@ -23,6 +23,7 @@ import { getChatId, formatChatExcerpt, callWithRetry } from './agent-utils.js';
 import { addBackgroundEvent, registerBackgroundTask } from './background-events.js';
 import { buildArcsSummary } from './arc-tracker.js';
 import { withWorldInfoAttribution } from './world-info-attribution.js';
+import { isOocUserTurn } from './turn-classification.js';
 
 const METADATA_KEY = 'tunnelvision_worldstate';
 
@@ -603,6 +604,7 @@ export function requestPriorityUpdate(reason) {
 function onAiMessageReceived() {
     const settings = getSettings();
     if (!settings.worldStateEnabled || settings.globalEnabled === false) return;
+    if (isOocUserTurn(getContext().chat)) return;
 
     // Skip tool-call recursion
     try {


### PR DESCRIPTION
An OOC aside is a question *about* the story, so it still needs story context to be answerable — `OOC what is her formal education level?` is precisely what sidecar retrieval exists for. **Retrieval runs unchanged on an OOC turn.** Only writing is suppressed.

### Why suppress the writes

An aside isn't something that happened in the scene, so remembering it is wrong on its own terms, and it costs a sidecar writer call every time.

To be precise about what does and doesn't survive a delete, since it's easy to overstate: entries the post-turn writer creates carry a `tv_tracker` key, so deleting the messages does clean them up via `revertInvalidSnapshots()` + `cleanInvalidSidecarMemories()`. That path self-heals, and the cost is the wasted call plus the churn — and #44 deliberately made that cleanup conservative, keeping anything it can't positively match.

Auto-summary is the path that doesn't self-heal, and #43 made it sharper. It now performs the summary itself via `runSummary()` rather than injecting an instruction the model may ignore, and summary entries are created with `constant: true` and **no** `tv_tracker`:

```js
result = await createEntry(lorebook, {
    content, comment: title, keys: ..., nodeId,
    constant: true,
});
```

No tracker means `cleanInvalidSidecarMemories` hits `if (!origin) continue;` and skips it permanently; `constant: true` additionally puts it inside `isStaticEntry()`'s protection. An aside folded into a summary stays there.

### How

Four paths:

- `suppressTunnelVisionWriteTools` strips the writing tools from that one request and keeps `TunnelVision_Search`, which only reads. Tools stay registered globally so the next in-character turn is unaffected, and tools from other extensions are untouched.
- the "you MUST call a tool this turn" instruction is withheld
- the post-turn sidecar writer returns early
- `memory-lifecycle`, `post-turn-processor`, `smart-context`, `world-state` and `auto-summary` return early on `MESSAGE_RECEIVED`

### Marker detection

Accepts the wrapped forms people actually use, not just a bare prefix:

| | |
|---|---|
| `OOC: how old is she?` | ✅ |
| `(OOC: how old is she?)` | ✅ |
| `((OOC: how old is she?))` | ✅ |
| `[OOC: how old is she?]` | ✅ |
| `<OOC> how old is she?` | ✅ |
| `**OOC** how old is she?` | ✅ |
| `[ she leaves the room ]` | ❌ |
| `(( a door slams ))` | ❌ |
| `*he shrugs*` | ❌ |
| `(occupied)` | ❌ |
| `OOCly phrased` | ❌ |
| `Wait, OOC, how old is she?` | ❌ |

It still requires the literal word as the first token. A bare `[ ... ]` or `(( ... ))` is deliberately **not** treated as OOC — those are action beats and sound effects, and suppressing writes on ordinary roleplay would be a worse failure than missing an aside.

Detection reads the pending `#send_textarea` value, because at `GENERATION_STARTED` ST hasn't yet copied normal input into the chat array — checking the chat alone catches the turn one turn late, which is one turn too many.

Slash-command generations reset the flag rather than inheriting it, and an explicit `/summarize` stays unguarded: that's the user asking for a summary, not an aside.

### Tests

25 tests covering the classifier and the tool stripping.

`upstream/main` currently fails 91 tests across 8 files (`activity-feed`, `embedding-cache`, `entry-manager`, `feed-helpers`, `shared-utils`, `smart-context`, `summary-hierarchy`, `tree-builder`) — all pre-existing and untouched here. This branch takes passing tests from 437 to 462 with no new failures.

Independent of #46 — no shared files beyond `index.js`, and no overlapping hunks there.
