### PR TITLE
fix(sidecar): stop stamping the user's ST origin on OpenRouter calls

### DIFF
--- a/llm-sidecar.js
+++ b/llm-sidecar.js
@@ -205,7 +205,7 @@ async function _callOpenAI({ endpoint, apiKey, model, systemPrompt, prompt, temp
     // Matches _embedOpenAI, which already sets the header conditionally.
     if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
     if (/openrouter\.ai/i.test(url)) {
-        headers['HTTP-Referer'] = (typeof window !== 'undefined' && window.location?.origin) || 'https://sillytavern.app';
+        headers['HTTP-Referer'] = 'https://sillytavern.app';
         headers['X-Title'] = 'TunnelVision';
     }
     const messages = [];


### PR DESCRIPTION
### This is a privacy leak, not a cosmetic change

Every sidecar call to OpenRouter sends `window.location.origin` as `HTTP-Referer` — the address the **user** reaches SillyTavern on. It goes to a third party on every request, and OpenRouter has no other way to obtain it.

What that exposes depends on the install:

- **LAN install** — the internal subnet and the port ST listens on, e.g. `http://192.168.x.x:8000/`
- **Tailscale name, ngrok tunnel, or a real domain** — that hostname, which is identifying

The sidecar runs in the browser, so the connection's source address is the machine's public exit IP. Private addresses do not survive NAT, and a tunnel hostname never touches the network layer at all. The header is the only carrier — without it the information is simply not available to OpenRouter.

It is not transient, either. It lands in the generation log's `origin` field and in the dashboard's App column, one row per sidecar call, for as long as OpenRouter retains logs. I noticed it because my own install's LAN address was sitting in that column.

### Since when

Five months, as of this PR. It came into being in [`1967271`](https://github.com/Coneja-Chibi/TunnelVision/commit/1967271dea62c78e7bde97dbf0947fe42917ca83) (2026-03-13, *"Sidecar LLM system, compact tool prompts, per-book permissions, tree editor enhancements, feed reasoning display, and runtime hardening"*):

https://github.com/Coneja-Chibi/TunnelVision/blob/1967271dea62c78e7bde97dbf0947fe42917ca83/llm-sidecar.js#L310-L313

I have touched the line once since, and would rather point that out than have you find it — [`07169b4`](https://github.com/Coneja-Chibi/TunnelVision/commit/07169b4079e90e7a1b01511310adc06135d30449) (2026-07-13), which wrapped it in `typeof window !== 'undefined'` with a `|| 'https://sillytavern.app'` fallback so the sidecar tests could run under Node:

https://github.com/Coneja-Chibi/TunnelVision/blob/07169b4079e90e7a1b01511310adc06135d30449/llm-sidecar.js#L169-L172

That guard does not change browser behaviour. In SillyTavern `window` is always defined, so `window.location.origin` is what ships — before and after. The leak is identical in both versions.

### The fix

```diff
 if (/openrouter\.ai/i.test(url)) {
-    headers['HTTP-Referer'] = (typeof window !== 'undefined' && window.location?.origin) || 'https://sillytavern.app';
+    headers['HTTP-Referer'] = 'https://sillytavern.app';
     headers['X-Title'] = 'TunnelVision';
 }
```

### Attribution is unaffected

The header exists for OpenRouter's app rankings, and this keeps that working:

- `X-Title: 'TunnelVision'` is untouched — app identity was never the referer's job.
- A fixed referer serves rankings *better* than a per-user one, since a single URL aggregates instead of splitting across every install's hostname.
- `https://sillytavern.app` is what SillyTavern's own server sends for OpenRouter requests (`src/constants.js`, `OPENROUTER_HEADERS`), so sidecar traffic lines up with the host app instead of appearing as an unregistered URL per install.

If you would rather it point at this repo than at SillyTavern, say so and I will change the literal — the leak is fixed either way.

### Notes

The `typeof window` guard existed only to keep `window.location` from throwing under Node in the test suite. A literal needs no guard.

`npx vitest run tests/llm-sidecar.test.js` — 62 passed, tests untouched.
