### PR TITLE
fix(sidecar): don't lose a turn's memory when the user swipes

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ import { initWorldState } from './world-state.js';
 import { initSmartContext } from './smart-context.js';
 import { initMemoryLifecycle } from './memory-lifecycle.js';
 import { runSidecarRetrieval, clearRetrievalPrompt } from './sidecar-retrieval.js';
-import { runSidecarWriter, revertInvalidSnapshots, hydrateSnapshots, cleanInvalidSidecarMemories } from './sidecar-writer.js';
+import { runSidecarWriterDraining, revertInvalidSnapshots, hydrateSnapshots, cleanInvalidSidecarMemories } from './sidecar-writer.js';
 import { abortSidecarFetches, isRetrievalScopeOpen } from './llm-sidecar.js';
 import { separateConditions, isEvaluableCondition, formatCondition, EVALUABLE_TYPES, CONDITION_LABELS, getKeywordProbability, setKeywordProbability } from './conditions.js';
 import { loadWorldInfo, saveWorldInfo, world_names } from '../../../world-info.js';
@@ -1159,10 +1159,6 @@ async function onGenerationStarted(type, opts, dryRun) {
 // Debounce timer for sidecar writer in group chats — prevents firing
 // once per group member by waiting for the last MESSAGE_RECEIVED.
 let _sidecarWriterDebounceTimer = null;
-// Re-entrancy guard: prevents overlapping runSidecarWriter() invocations when
-// MESSAGE_RECEIVED fires again (e.g. a fast follow-up message) while a
-// previous writer run is still in flight.
-let _writerRunning = false;
 
 async function onMessageReceived(messageId, type) {
     console.debug(`[TunnelVision] MESSAGE_RECEIVED: messageId=${messageId} type="${type}"`);
@@ -1194,37 +1190,23 @@ async function onMessageReceived(messageId, type) {
     const settings = getSettings();
     if (!settings.sidecarPostGenWriter || settings.globalEnabled === false) return;
 
-    if (_writerRunning) return;
-
     // In group chats, debounce: wait 800ms after the last MESSAGE_RECEIVED
     // before firing the sidecar writer, so we only run once after the
     // final group member's message instead of N times.
     const context = getContext();
     if (context.groupId) {
         if (_sidecarWriterDebounceTimer) clearTimeout(_sidecarWriterDebounceTimer);
-        _sidecarWriterDebounceTimer = setTimeout(async () => {
+        _sidecarWriterDebounceTimer = setTimeout(() => {
             _sidecarWriterDebounceTimer = null;
-            if (_writerRunning) return;
-            _writerRunning = true;
-            try {
-                await runSidecarWriter(messageId);
-            } catch (err) {
-                console.error('[TunnelVision] Sidecar post-gen writer error (group):', err);
-            } finally {
-                _writerRunning = false;
-            }
+            runSidecarWriterDraining(messageId);
         }, 800);
         return;
     }
 
-    _writerRunning = true;
-    try {
-        await runSidecarWriter(messageId);
-    } catch (err) {
-        console.error('[TunnelVision] Sidecar post-gen writer error:', err);
-    } finally {
-        _writerRunning = false;
-    }
+    // Concurrency lives in runSidecarWriterDraining: it owns the re-entrancy
+    // guard and re-runs for a response that arrived mid-run, so a swipe landing
+    // while the writer is busy still gets memorized.
+    await runSidecarWriterDraining(messageId);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ import { abortSidecarFetches, isRetrievalScopeOpen } from './llm-sidecar.js';
 import { separateConditions, isEvaluableCondition, formatCondition, EVALUABLE_TYPES, CONDITION_LABELS, getKeywordProbability, setKeywordProbability } from './conditions.js';
 import { loadWorldInfo, saveWorldInfo, world_names } from '../../../world-info.js';
 import { findEntryByUid } from './entry-manager.js';
-import { isOocTurn, isOocUserTurn, suppressTunnelVisionWriteTools } from './turn-classification.js';
+import { isOocTurn, isOocUserTurn, shouldRunSidecarWriter, suppressTunnelVisionWriteTools } from './turn-classification.js';
 
 const EXTENSION_NAME = 'tunnelvision';
 const EXTENSION_FOLDER = `third-party/TunnelVision`;
@@ -1185,10 +1185,11 @@ async function onMessageReceived(messageId, type) {
         return;
     }
 
-    // Never run sidecar writer on swipes, continues, first messages, regenerations,
-    // or non-generation events. Only run on normal 'normal' generation completions.
-    const skipTypes = ['swipe', 'continue', 'appendFinal', 'first_message', 'command', 'extension', 'regenerate'];
-    if (skipTypes.includes(type)) return;
+    // Continues, first messages, regenerations and non-generation events must not
+    // run the writer. Swipes must: the swipe branch on MESSAGE_RECEIVED has already
+    // reverted the previous response's writes, so returning here would leave the
+    // turn with no memory at all.
+    if (!shouldRunSidecarWriter(type)) return;
 
     const settings = getSettings();
     if (!settings.sidecarPostGenWriter || settings.globalEnabled === false) return;

--- a/message-identity.js
+++ b/message-identity.js
@@ -11,6 +11,13 @@
 export const MESSAGE_ID_FIELD = 'tunnelvision_message_id';
 export const CHAT_ID_METADATA_KEY = 'tunnelvision_chat_identity';
 const ORIGIN_VERSION = 'v2';
+/**
+ * Numeric marker parseOriginPayload() stamps on a parsed v2 origin. Origins
+ * built by hand (rather than parsed from a key) must carry it too, or the
+ * fingerprint comparison in locateOriginMessage() silently falls back to the
+ * legacy scheme and never matches.
+ */
+export const CURRENT_ORIGIN_VERSION = 2;
 const SNAPSHOT_PREFIX = `${ORIGIN_VERSION}:`;
 const TRACKER_PREFIX = '!tv_tracker:';
 const STABLE_ID_PREFIX = 'tvmsg_';

--- a/sidecar-writer.js
+++ b/sidecar-writer.js
@@ -38,6 +38,7 @@ import { saveSettingsDebounced } from '../../../../script.js';
 import { applyBackgroundPromptAddendum, buildLanguageDirective, trigramSimilarity } from './agent-utils.js';
 import { isStaticEntry } from './entry-protection.js';
 import {
+    CURRENT_ORIGIN_VERSION,
     ensureChatIdentity,
     ensureMessageIdentity,
     getMessageFingerprint,
@@ -1002,10 +1003,21 @@ export async function excludeStaticWriteOps(ops) {
  * @param {{chatId:string, messageId:string, fingerprint:string}} origin
  * @returns {Promise<{succeeded: number, failed: number, results: string[]}>}
  */
-async function executeWriteOps(ops, reasoning = '', origin) {
+export async function executeWriteOps(ops, reasoning = '', origin) {
     const results = [];
     let succeeded = 0;
     let failed = 0;
+
+    // `origin` was captured before the sidecar call, which takes seconds. A swipe
+    // or deletion in that window replaces the source message — and the revert pass
+    // that ran on that swipe has already been and gone. Committing now would attach
+    // this turn's memories to a response that no longer exists, leaving entries no
+    // later revert is keyed to find.
+    const located = locateOriginMessage(getContext().chat, { ...origin, version: CURRENT_ORIGIN_VERSION });
+    if (located.status === 'invalid') {
+        console.log('[TunnelVision] Sidecar writer: source message changed mid-run — discarding writes');
+        return { succeeded, failed, skipped: ops.length, results };
+    }
 
     const snapshotKey = makeSnapshotKey(origin.messageId, origin.fingerprint);
     const tv_tracker = makeTrackerKey(origin.chatId, origin.messageId, origin.fingerprint);

--- a/sidecar-writer.js
+++ b/sidecar-writer.js
@@ -1391,3 +1391,50 @@ export async function runSidecarWriter(messageId = null) {
         console.error('[TunnelVision] Sidecar post-gen writer failed:', error);
     }
 }
+
+// Re-entrancy guard for runSidecarWriter, plus the single message slot for a
+// response that arrived while it was busy.
+let _writerRunning = false;
+let _writerPendingMessageId = null;
+
+/**
+ * Run the sidecar writer, then run it again for any message that landed while it
+ * was busy.
+ *
+ * Without the drain, a swipe arriving mid-run is dropped by the re-entrancy
+ * guard while the in-flight run has its own writes discarded by the origin check
+ * in executeWriteOps — correct individually, but together they leave that turn
+ * with no memory at all.
+ *
+ * One pending slot is enough. Swiping repeatedly replaces the same message, so
+ * only the most recent one is still in the chat; earlier entries would fail the
+ * origin check anyway. The loop ends when nothing new has arrived.
+ *
+ * @param {number|string|null} messageId
+ * @param {(messageId: number|string|null) => Promise<void>} [run] seam for tests
+ * @returns {Promise<void>}
+ */
+export async function runSidecarWriterDraining(messageId, run = runSidecarWriter) {
+    if (_writerRunning) {
+        _writerPendingMessageId = messageId;
+        return;
+    }
+
+    _writerRunning = true;
+    try {
+        let nextMessageId = messageId;
+        while (nextMessageId !== null && nextMessageId !== undefined) {
+            _writerPendingMessageId = null;
+            try {
+                await run(nextMessageId);
+            } catch (error) {
+                // A failed run must not strand a queued swipe.
+                console.error('[TunnelVision] Sidecar post-gen writer error:', error);
+            }
+            nextMessageId = _writerPendingMessageId;
+        }
+    } finally {
+        _writerRunning = false;
+        _writerPendingMessageId = null;
+    }
+}

--- a/tests/sidecar-snapshots.test.js
+++ b/tests/sidecar-snapshots.test.js
@@ -57,9 +57,11 @@ vi.mock('../agent-utils.js', () => ({
 import { getContext } from '../../../st-context.js';
 import { deleteWorldInfoEntry, loadWorldInfo, saveWorldInfo } from '../../../world-info.js';
 import { logSnapshotRevert } from '../activity-feed.js';
+import { resolveTargetBook } from '../tool-registry.js';
 import {
     cleanInvalidSidecarMemories,
     excludeStaticWriteOps,
+    executeWriteOps,
     hydrateSnapshots,
     revertInvalidSnapshots,
     revertMessageSnapshots,
@@ -324,5 +326,53 @@ describe('sidecar static-entry protection', () => {
         ]);
         expect(skipped).toHaveLength(5);
         expect(skipped.every(message => message.includes('static entry "Canon"'))).toBe(true);
+    });
+});
+
+describe('write ops guard against a mid-run swipe', () => {
+    // The sidecar call between capturing `origin` and committing takes seconds.
+    // A swipe in that window replaces the message text and runs its revert pass
+    // before the writer returns, so committing afterwards would strand entries
+    // keyed to a fingerprint nothing can revert.
+    function originFor(message) {
+        return {
+            chatId: 'tvchat_1',
+            messageId: message[MESSAGE_ID_FIELD],
+            fingerprint: getMessageFingerprint(message),
+        };
+    }
+
+    const OPS = [{ type: 'remember', lorebook: 'Book', title: 'T', content: 'C', keys: ['k'] }];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('discards the writes when the source message changed mid-run', async () => {
+        const message = { [MESSAGE_ID_FIELD]: 'tvmsg_swiped', mes: 'original response' };
+        const origin = originFor(message);
+
+        // The swipe: same message object and identity, new text.
+        message.mes = 'the swiped-to response';
+        getContext.mockReturnValue(makeContext({}, [message]));
+
+        const result = await executeWriteOps(OPS, '', origin);
+
+        expect(result.succeeded).toBe(0);
+        expect(result.skipped).toBe(OPS.length);
+        expect(loadWorldInfo).not.toHaveBeenCalled();
+        expect(saveWorldInfo).not.toHaveBeenCalled();
+    });
+
+    it('proceeds past the guard when the source message is unchanged', async () => {
+        const message = { [MESSAGE_ID_FIELD]: 'tvmsg_intact', mes: 'original response' };
+        getContext.mockReturnValue(makeContext({}, [message]));
+        resolveTargetBook.mockReturnValue({ book: 'Book' });
+
+        // Downstream tool definitions are stubbed in this file, so the call throws
+        // once it gets past snapshotting. Reaching loadWorldInfo is the assertion.
+        await executeWriteOps(OPS, '', originFor(message)).catch(() => {});
+
+        expect(loadWorldInfo).toHaveBeenCalled();
     });
 });

--- a/tests/sidecar-snapshots.test.js
+++ b/tests/sidecar-snapshots.test.js
@@ -62,6 +62,7 @@ import {
     cleanInvalidSidecarMemories,
     excludeStaticWriteOps,
     executeWriteOps,
+    runSidecarWriterDraining,
     hydrateSnapshots,
     revertInvalidSnapshots,
     revertMessageSnapshots,
@@ -374,5 +375,60 @@ describe('write ops guard against a mid-run swipe', () => {
         await executeWriteOps(OPS, '', originFor(message)).catch(() => {});
 
         expect(loadWorldInfo).toHaveBeenCalled();
+    });
+});
+
+describe('writer drain for a swipe that lands mid-run', () => {
+    it('re-runs for the message that arrived while the writer was busy', async () => {
+        const seen = [];
+        const run = vi.fn(async (id) => {
+            seen.push(id);
+            // The swipe's MESSAGE_RECEIVED, fired while this run is still going.
+            if (seen.length === 1) await runSidecarWriterDraining(7, run);
+        });
+
+        await runSidecarWriterDraining(3, run);
+
+        expect(seen).toEqual([3, 7]);
+    });
+
+    it('coalesces repeated swipes to the last one, which is the survivor', async () => {
+        const seen = [];
+        const run = vi.fn(async (id) => {
+            seen.push(id);
+            if (seen.length === 1) {
+                await runSidecarWriterDraining(7, run);
+                await runSidecarWriterDraining(8, run);
+                await runSidecarWriterDraining(9, run);
+            }
+        });
+
+        await runSidecarWriterDraining(3, run);
+
+        expect(seen).toEqual([3, 9]);
+    });
+
+    it('still drains a queued swipe when the previous run throws', async () => {
+        const seen = [];
+        const run = vi.fn(async (id) => {
+            seen.push(id);
+            if (seen.length === 1) {
+                await runSidecarWriterDraining(7, run);
+                throw new Error('sidecar exploded');
+            }
+        });
+
+        await expect(runSidecarWriterDraining(3, run)).resolves.toBeUndefined();
+
+        expect(seen).toEqual([3, 7]);
+    });
+
+    it('releases the guard so a later turn is not locked out', async () => {
+        const run = vi.fn(async () => {});
+
+        await runSidecarWriterDraining(1, run);
+        await runSidecarWriterDraining(2, run);
+
+        expect(run).toHaveBeenCalledTimes(2);
     });
 });

--- a/tests/turn-classification.test.js
+++ b/tests/turn-classification.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isOocMessage, isOocTurn, isOocUserTurn, suppressTunnelVisionWriteTools } from '../turn-classification.js';
+import { isOocMessage, isOocTurn, isOocUserTurn, shouldRunSidecarWriter, suppressTunnelVisionWriteTools } from '../turn-classification.js';
 
 describe('OOC turn classification', () => {
     it.each([
@@ -131,5 +131,29 @@ describe('OOC request tool suppression', () => {
         expect(suppressTunnelVisionWriteTools(request)).toBe(1);
         expect(request.tools).toBeUndefined();
         expect(request.tool_choice).toBe('none');
+    });
+});
+
+describe('sidecar writer generation types', () => {
+    // Regression: 'swipe' used to sit in the skip list, so a swipe reverted the
+    // previous response's memories and then wrote none for the new one.
+    it('runs on a swipe', () => {
+        expect(shouldRunSidecarWriter('swipe')).toBe(true);
+    });
+
+    it('runs on a normal completion and on an unlabelled type', () => {
+        expect(shouldRunSidecarWriter('normal')).toBe(true);
+        expect(shouldRunSidecarWriter(undefined)).toBe(true);
+    });
+
+    it.each([
+        'continue',
+        'appendFinal',
+        'first_message',
+        'command',
+        'extension',
+        'regenerate',
+    ])('does not run on %j', (type) => {
+        expect(shouldRunSidecarWriter(type)).toBe(false);
     });
 });

--- a/turn-classification.js
+++ b/turn-classification.js
@@ -87,3 +87,33 @@ export function suppressTunnelVisionWriteTools(data) {
 
     return removed;
 }
+
+/**
+ * Generation types that must never trigger the post-generation sidecar writer.
+ *
+ * `swipe` is deliberately NOT here. MESSAGE_RECEIVED reverts the previous
+ * response's lorebook writes on a swipe (revertInvalidSnapshots), so skipping
+ * the writer too left that turn with no memory at all — swiping to a response
+ * you like is exactly when you want the *new* response memorized.
+ *
+ * `regenerate` stays skipped: unlike swipe it gets no revert pass, so running
+ * the writer there would stack new memories on top of the old response's.
+ */
+const NON_WRITER_GENERATION_TYPES = new Set([
+    'continue',
+    'appendFinal',
+    'first_message',
+    'command',
+    'extension',
+    'regenerate',
+]);
+
+/**
+ * Whether a MESSAGE_RECEIVED generation type should run the sidecar writer.
+ *
+ * @param {*} type
+ * @returns {boolean}
+ */
+export function shouldRunSidecarWriter(type) {
+    return !NON_WRITER_GENERATION_TYPES.has(String(type ?? ''));
+}


### PR DESCRIPTION
Swiping silently lost that turn's memory.

`MESSAGE_RECEIVED` already reverts the previous response's lorebook writes when
`type === "swipe"` — the swiped-to text no longer matches the snapshot
fingerprint, so `revertInvalidSnapshots()` correctly undoes them. But `"swipe"`
also sat in `onMessageReceived`'s `skipTypes` list, so the writer never ran for
the new response.

Together those meant a swipe undid the old turn's memories and wrote none for
the new one. Swipe to a response you like and nothing from that turn was
remembered, permanently. `post-turn-processor.js` already had the right shape
for this (`rollbackLastPostTurn()` then `runPostTurnProcessor()`); the sidecar
writer path did the rollback and skipped the re-run.

Three commits, each a separate concern:

**1. Run the writer on swipes.** The skip list moves to `turn-classification.js`
next to the other generation-type predicates so its entries carry their
reasoning and can be tested. `"regenerate"` deliberately stays skipped: it gets
no revert pass, so running the writer there would stack new memories on top of
the old response's rather than replacing them.

**2. Discard writer output when the source message changed mid-run.**
`runSidecarWriter` captures `origin` before asking the sidecar what to write,
then commits with it seconds later, and nothing re-checked it in between. A
swipe or delete in that window means the revert pass has already run and
finished, so the writes land keyed to a fingerprint no longer in the chat —
memories attached to a response that no longer exists, which no later revert can
find. This race predates commit 1 (it exists on the normal-generation → swipe
path today); running the writer on every swipe makes it routine. Re-validating
`origin` at the top of `executeWriteOps` covers swipe, delete and edit at once.

Worth knowing for review: `locateOriginMessage` treats an origin without
`version: 2` as a legacy record and compares it against
`getLegacyMessageFingerprint`, which can never match a v2 `f1_` fingerprint. The
origin literal in `runSidecarWriter` has no `version` field, so the guard is
stamped at the point of comparison rather than where `origin` is built —
otherwise every write would be silently discarded.

**3. Re-run the writer for a swipe that lands mid-run.** With 1 and 2 in place,
a swipe arriving while the writer was still working hit the `_writerRunning`
re-entrancy guard and was dropped, while the in-flight run had its own writes
discarded by 2. Both correct individually; together they reproduced the original
symptom whenever the sidecar was slower than the main model.
`runSidecarWriterDraining` now owns the guard plus a single pending-message
slot, and loops until nothing new has arrived. One slot suffices: repeated
swipes replace the same message, so only the newest is still in the chat and
older ones would fail the origin check anyway. This also collapses the two
duplicated run-with-guard blocks in `index.js` (group-debounce and normal paths)
into one call.

Note the in-flight sidecar call is not aborted — it completes and costs its
tokens; only its writes are discarded. Cancelling mid-flight wasn't built.

## Tests

14 new tests: `shouldRunSidecarWriter` pinned per generation type, the origin
guard covered both ways (stale origin discards and never reaches
`loadWorldInfo`; unchanged origin proceeds), and the drain covered for re-run,
coalescing three rapid swipes to the last, draining when the previous run
throws, and releasing the guard afterwards.

`vitest run` on this branch: **485 passing**, against **471** on `main` at
`a01d7ee`. Both runs show the same 91 pre-existing failures in `tree-builder`,
`entry-manager` and `activity-feed` — they reproduce on a clean `main` checkout
and are untouched by this branch.
