### PR TITLE
Make the tree editor usable on a phone

### DIFF
--- a/style.css
+++ b/style.css
@@ -778,277 +778,6 @@
     50% { opacity: 0.7; }
 }
 
-/* ===== Responsive Adjustments ===== */
-@media (max-width: 768px) {
-    /* --- Settings panel --- */
-    .tv-header {
-        padding: 10px 14px;
-    }
-
-    .tv-header-icon {
-        font-size: 18px;
-    }
-
-    .tv-header-title {
-        font-size: 13px;
-    }
-
-    .tv-header-subtitle {
-        font-size: 10px;
-    }
-
-    .tv-card-body {
-        padding: 8px;
-    }
-
-    .tv-button-row {
-        flex-direction: column;
-    }
-
-    .tv-card-header-actions {
-        flex-wrap: wrap;
-        gap: 4px;
-    }
-
-    /* --- Activity feed --- */
-    /* Mobile: larger touch target, move above bottom nav */
-    .tv-float-trigger {
-        width: 44px;
-        height: 44px;
-        font-size: 17px;
-        bottom: 120px;
-    }
-
-    /* Mobile: full-width panel */
-    .tv-float-panel {
-        width: calc(100vw - 32px);
-        max-height: 50vh;
-        left: 16px !important;
-        right: 16px;
-    }
-
-    /* --- Tree editor popup: drop the sidebar, navigate in the main panel ---
-       Stacking the sidebar above the main panel meant tapping a node at the top,
-       scrolling past the whole tree to reach its entries, then scrolling back up
-       for the next one. The main panel is already a drill-down navigator -- the
-       breadcrumb goes up, the child cards go down -- so the sidebar is a second
-       navigator for the same tree, and hiding it gives the panel the full height
-       with one scroll region. */
-    .tv-popup-body {
-        flex-direction: column;
-    }
-
-    .tv-tree-sidebar {
-        display: none;
-    }
-
-    .tv-main-panel {
-        min-height: 200px;
-    }
-
-    /* The breadcrumb is the back button here, so it needs a real touch target. */
-    .tv-main-breadcrumb {
-        font-size: 13px;
-        gap: 6px;
-        margin-bottom: 6px;
-    }
-
-    .tv-bc-crumb {
-        padding: 4px 2px;
-    }
-
-    .tv-main-header {
-        padding: 10px 12px 8px;
-    }
-
-    .tv-main-body {
-        padding: 10px 12px;
-    }
-
-    .tv-main-title {
-        font-size: 15px;
-    }
-
-    .tv-main-title-static {
-        font-size: 15px;
-    }
-
-    /* --- Popup toolbar: wrap buttons ---
-       The toolbar wraps its two halves, but tv-popup-toolbar-right is itself a
-       flex row of five buttons and has to wrap too -- a flex item defaults to
-       min-width: auto, so without this it refuses to shrink and the delete
-       button ends up past the popup's right edge, unreachable. */
-    .tv-popup-toolbar {
-        flex-wrap: wrap;
-        gap: 8px;
-        padding: 8px 10px;
-    }
-
-    .tv-popup-toolbar-left,
-    .tv-popup-toolbar-right {
-        gap: 6px;
-        flex-wrap: wrap;
-        min-width: 0;
-    }
-
-    .tv-popup-btn {
-        padding: 6px 10px;
-        font-size: 11px;
-        min-height: 34px;
-    }
-
-    .tv-popup-search {
-        width: 100%;
-        order: 10;
-    }
-
-    /* 16px, not smaller: iOS Safari auto-zooms on focusing a sub-16px input
-       and never zooms back, leaving the rest of the popup off-screen. */
-    .tv-popup-search input {
-        font-size: 16px;
-    }
-
-    /* --- Tree nodes: bigger touch targets --- */
-    .tv-tree-row {
-        padding: 6px 8px;
-        min-height: 34px;
-        font-size: 13px;
-    }
-
-    .tv-tree-toggle {
-        width: 20px;
-        font-size: 10px;
-        padding: 4px 0;
-    }
-
-    .tv-tree-dot {
-        width: 8px;
-        height: 8px;
-    }
-
-    .tv-tree-children {
-        padding-left: 12px;
-        margin-left: 6px;
-    }
-
-    /* --- Entry rows: larger touch targets --- */
-    .tv-entry-row {
-        padding: 8px 10px;
-        min-height: 40px;
-        gap: 6px;
-    }
-
-    .tv-entry-name {
-        font-size: 12px;
-    }
-
-    .tv-entry-toggle,
-    .tv-entry-remove,
-    .tv-entry-tracker,
-    .tv-entry-move {
-        opacity: 1;
-        padding: 4px;
-    }
-
-    /* Drop targets, not just labels — rows need a real touch target. */
-    .tv-move-picker-row {
-        min-height: 40px;
-    }
-
-    .tv-entry-drag {
-        display: none;
-    }
-
-    /* --- Expanded entry detail --- */
-    .tv-expand-section {
-        gap: 8px;
-    }
-
-    .tv-expand-content {
-        font-size: 12px;
-        max-height: 200px;
-    }
-
-    .tv-expand-content-edit {
-        min-height: 100px;
-        font-size: 16px;
-    }
-
-    /* --- Node summary box --- */
-    .tv-node-summary {
-        padding: 8px 10px;
-        margin-bottom: 12px;
-    }
-
-    /* --- Child node cards: stack vertically --- */
-    .tv-child-cards {
-        gap: 6px;
-    }
-
-    /* --- Kanban mini overview --- */
-    .tv-mini-cat {
-        padding: 5px 8px;
-    }
-
-    .tv-mini-cat-name {
-        font-size: 11px;
-    }
-
-    /* --- Unassigned chips --- */
-    .tv-unassigned-chip {
-        font-size: 11px;
-        padding: 6px 10px;
-    }
-
-    /* --- Confirmation popup --- */
-    .tv-confirm-args {
-        max-height: 200px;
-    }
-    .tv-confirm-diff {
-        max-height: 240px;
-    }
-    .tv-confirm-pre {
-        max-height: 180px;
-    }
-
-    /* --- Tool prompt overrides --- */
-    .tv-tool-prompt-textarea {
-        min-height: 60px;
-        font-size: 12px;
-    }
-
-    /* --- Misc mobile fixes --- */
-    .tv-tree-view {
-        max-height: 350px;
-    }
-
-    /* Advanced settings: tighter spacing */
-    .tv-adv-section-title {
-        font-size: 11px;
-    }
-
-    .tv-radio {
-        padding: 8px;
-    }
-
-    .tv-radio-label {
-        font-size: 12px;
-    }
-
-    /* --- Popup editor: reduce min-height for small screens --- */
-    .tv-popup-editor {
-        min-height: 300px;
-    }
-
-    /* --- Settings selects/inputs: full width --- */
-    .tv-container select,
-    .tv-container input[type="text"],
-    .tv-container input[type="number"],
-    .tv-container textarea {
-        font-size: 14px;
-    }
-}
-
 /* ===== Advanced Settings ===== */
 
 .tv-adv-section {
@@ -2922,4 +2651,279 @@ details.tv-confirm-diff-wrap[open] .tv-confirm-diff-summary::before { content: '
 
 .tv-adv-search-clear.tv-visible {
     display: inline-block;
+}
+
+/* ===== Responsive Adjustments =====
+   MUST STAY LAST IN THIS FILE. A media query adds no specificity, so these
+   rules only beat their base counterparts by coming later in source order.
+   This block used to sit above them and 33 of its declarations silently lost
+   -- the sidebar never hid, inputs stayed at 13px, touch targets stayed small. */
+@media (max-width: 768px) {
+    /* --- Settings panel --- */
+    .tv-header {
+        padding: 10px 14px;
+    }
+
+    .tv-header-icon {
+        font-size: 18px;
+    }
+
+    .tv-header-title {
+        font-size: 13px;
+    }
+
+    .tv-header-subtitle {
+        font-size: 10px;
+    }
+
+    .tv-card-body {
+        padding: 8px;
+    }
+
+    .tv-button-row {
+        flex-direction: column;
+    }
+
+    .tv-card-header-actions {
+        flex-wrap: wrap;
+        gap: 4px;
+    }
+
+    /* --- Activity feed --- */
+    /* Mobile: larger touch target, move above bottom nav */
+    .tv-float-trigger {
+        width: 44px;
+        height: 44px;
+        font-size: 17px;
+        bottom: 120px;
+    }
+
+    /* Mobile: full-width panel */
+    .tv-float-panel {
+        width: calc(100vw - 32px);
+        max-height: 50vh;
+        left: 16px !important;
+        right: 16px;
+    }
+
+    /* --- Tree editor popup: drop the sidebar, navigate in the main panel ---
+       Stacking the sidebar above the main panel meant tapping a node at the top,
+       scrolling past the whole tree to reach its entries, then scrolling back up
+       for the next one. The main panel is already a drill-down navigator -- the
+       breadcrumb goes up, the child cards go down -- so the sidebar is a second
+       navigator for the same tree, and hiding it gives the panel the full height
+       with one scroll region. */
+    .tv-popup-body {
+        flex-direction: column;
+    }
+
+    .tv-tree-sidebar {
+        display: none;
+    }
+
+    .tv-main-panel {
+        min-height: 200px;
+    }
+
+    /* The breadcrumb is the back button here, so it needs a real touch target. */
+    .tv-main-breadcrumb {
+        font-size: 13px;
+        gap: 6px;
+        margin-bottom: 6px;
+    }
+
+    .tv-bc-crumb {
+        padding: 4px 2px;
+    }
+
+    .tv-main-header {
+        padding: 10px 12px 8px;
+    }
+
+    .tv-main-body {
+        padding: 10px 12px;
+    }
+
+    .tv-main-title {
+        font-size: 15px;
+    }
+
+    .tv-main-title-static {
+        font-size: 15px;
+    }
+
+    /* --- Popup toolbar: wrap buttons ---
+       The toolbar wraps its two halves, but tv-popup-toolbar-right is itself a
+       flex row of five buttons and has to wrap too -- a flex item defaults to
+       min-width: auto, so without this it refuses to shrink and the delete
+       button ends up past the popup's right edge, unreachable. */
+    .tv-popup-toolbar {
+        flex-wrap: wrap;
+        gap: 8px;
+        padding: 8px 10px;
+    }
+
+    .tv-popup-toolbar-left,
+    .tv-popup-toolbar-right {
+        gap: 6px;
+        flex-wrap: wrap;
+        min-width: 0;
+    }
+
+    .tv-popup-btn {
+        padding: 6px 10px;
+        font-size: 11px;
+        min-height: 34px;
+    }
+
+    .tv-popup-search {
+        width: 100%;
+        order: 10;
+    }
+
+    /* 16px, not smaller: iOS Safari auto-zooms on focusing a sub-16px input
+       and never zooms back, leaving the rest of the popup off-screen. */
+    .tv-popup-search input {
+        font-size: 16px;
+    }
+
+    /* --- Tree nodes: bigger touch targets --- */
+    .tv-tree-row {
+        padding: 6px 8px;
+        min-height: 34px;
+        font-size: 13px;
+    }
+
+    .tv-tree-toggle {
+        width: 20px;
+        font-size: 10px;
+        padding: 4px 0;
+    }
+
+    .tv-tree-dot {
+        width: 8px;
+        height: 8px;
+    }
+
+    .tv-tree-children {
+        padding-left: 12px;
+        margin-left: 6px;
+    }
+
+    /* --- Entry rows: larger touch targets --- */
+    .tv-entry-row {
+        padding: 8px 10px;
+        min-height: 40px;
+        gap: 6px;
+    }
+
+    .tv-entry-name {
+        font-size: 12px;
+    }
+
+    .tv-entry-toggle,
+    .tv-entry-remove,
+    .tv-entry-tracker,
+    .tv-entry-move {
+        opacity: 1;
+        padding: 4px;
+    }
+
+    /* Drop targets, not just labels — rows need a real touch target. */
+    .tv-move-picker-row {
+        min-height: 40px;
+    }
+
+    .tv-entry-drag {
+        display: none;
+    }
+
+    /* --- Expanded entry detail --- */
+    .tv-expand-section {
+        gap: 8px;
+    }
+
+    .tv-expand-content {
+        font-size: 12px;
+        max-height: 200px;
+    }
+
+    .tv-expand-content-edit {
+        min-height: 100px;
+        font-size: 16px;
+    }
+
+    /* --- Node summary box --- */
+    .tv-node-summary {
+        padding: 8px 10px;
+        margin-bottom: 12px;
+    }
+
+    /* --- Child node cards: stack vertically --- */
+    .tv-child-cards {
+        gap: 6px;
+    }
+
+    /* --- Kanban mini overview --- */
+    .tv-mini-cat {
+        padding: 5px 8px;
+    }
+
+    .tv-mini-cat-name {
+        font-size: 11px;
+    }
+
+    /* --- Unassigned chips --- */
+    .tv-unassigned-chip {
+        font-size: 11px;
+        padding: 6px 10px;
+    }
+
+    /* --- Confirmation popup --- */
+    .tv-confirm-args {
+        max-height: 200px;
+    }
+    .tv-confirm-diff {
+        max-height: 240px;
+    }
+    .tv-confirm-pre {
+        max-height: 180px;
+    }
+
+    /* --- Tool prompt overrides --- */
+    .tv-tool-prompt-textarea {
+        min-height: 60px;
+        font-size: 12px;
+    }
+
+    /* --- Misc mobile fixes --- */
+    .tv-tree-view {
+        max-height: 350px;
+    }
+
+    /* Advanced settings: tighter spacing */
+    .tv-adv-section-title {
+        font-size: 11px;
+    }
+
+    .tv-radio {
+        padding: 8px;
+    }
+
+    .tv-radio-label {
+        font-size: 12px;
+    }
+
+    /* --- Popup editor: reduce min-height for small screens --- */
+    .tv-popup-editor {
+        min-height: 300px;
+    }
+
+    /* --- Settings selects/inputs: full width --- */
+    .tv-container select,
+    .tv-container input[type="text"],
+    .tv-container input[type="number"],
+    .tv-container textarea {
+        font-size: 14px;
+    }
 }

--- a/style.css
+++ b/style.css
@@ -828,20 +828,19 @@
     }
 
     /* --- Tree editor popup: stack sidebar above main panel ---
-       Stacked, the sidebar and main panel are their own scroll regions nested
-       inside the popup's own vertical scroll. Three scrollers in a 90dvh box
-       leaves the entry list ~200px tall, so let the whole column scroll as one. */
+       The sidebar and main panel must keep their own scroll regions here.
+       .tv-popup-editor is height: 100%, so the editor can never grow past the
+       popup and .popup-content has nothing to scroll -- take the inner
+       scrollers away and the overflow becomes unreachable instead. */
     .tv-popup-body {
         flex-direction: column;
-        overflow: visible;
     }
 
     .tv-tree-sidebar {
         width: 100%;
-        max-height: none;
+        max-height: 40vh;
         border-right: none;
         border-bottom: 1px solid var(--SmartThemeBorderColor, #444);
-        overflow: visible;
     }
 
     .tv-tree-sidebar-header {
@@ -850,12 +849,10 @@
 
     .tv-tree-sidebar-scroll {
         padding: 4px;
-        overflow: visible;
     }
 
     .tv-main-panel {
         min-height: 200px;
-        overflow: visible;
     }
 
     .tv-main-header {
@@ -864,7 +861,6 @@
 
     .tv-main-body {
         padding: 10px 12px;
-        overflow: visible;
     }
 
     .tv-main-title {
@@ -875,7 +871,11 @@
         font-size: 15px;
     }
 
-    /* --- Popup toolbar: wrap buttons --- */
+    /* --- Popup toolbar: wrap buttons ---
+       The toolbar wraps its two halves, but tv-popup-toolbar-right is itself a
+       flex row of five buttons and has to wrap too -- a flex item defaults to
+       min-width: auto, so without this it refuses to shrink and the delete
+       button ends up past the popup's right edge, unreachable. */
     .tv-popup-toolbar {
         flex-wrap: wrap;
         gap: 8px;
@@ -885,6 +885,8 @@
     .tv-popup-toolbar-left,
     .tv-popup-toolbar-right {
         gap: 6px;
+        flex-wrap: wrap;
+        min-width: 0;
     }
 
     .tv-popup-btn {

--- a/style.css
+++ b/style.css
@@ -2829,6 +2829,12 @@ details.tv-confirm-diff-wrap[open] .tv-confirm-diff-summary::before { content: '
         padding: 4px;
     }
 
+    /* Push the one destructive button away from the rest of the group -- a thumb
+       is far less precise than a cursor, and these sit shoulder to shoulder. */
+    .tv-entry-remove {
+        margin-left: 10px;
+    }
+
     /* Drop targets, not just labels — rows need a real touch target. */
     .tv-move-picker-row {
         min-height: 40px;

--- a/style.css
+++ b/style.css
@@ -827,16 +827,21 @@
         right: 16px;
     }
 
-    /* --- Tree editor popup: stack sidebar above main panel --- */
+    /* --- Tree editor popup: stack sidebar above main panel ---
+       Stacked, the sidebar and main panel are their own scroll regions nested
+       inside the popup's own vertical scroll. Three scrollers in a 90dvh box
+       leaves the entry list ~200px tall, so let the whole column scroll as one. */
     .tv-popup-body {
         flex-direction: column;
+        overflow: visible;
     }
 
     .tv-tree-sidebar {
         width: 100%;
-        max-height: 40vh;
+        max-height: none;
         border-right: none;
         border-bottom: 1px solid var(--SmartThemeBorderColor, #444);
+        overflow: visible;
     }
 
     .tv-tree-sidebar-header {
@@ -845,10 +850,12 @@
 
     .tv-tree-sidebar-scroll {
         padding: 4px;
+        overflow: visible;
     }
 
     .tv-main-panel {
         min-height: 200px;
+        overflow: visible;
     }
 
     .tv-main-header {
@@ -857,6 +864,7 @@
 
     .tv-main-body {
         padding: 10px 12px;
+        overflow: visible;
     }
 
     .tv-main-title {
@@ -890,8 +898,10 @@
         order: 10;
     }
 
+    /* 16px, not smaller: iOS Safari auto-zooms on focusing a sub-16px input
+       and never zooms back, leaving the rest of the popup off-screen. */
     .tv-popup-search input {
-        font-size: 13px;
+        font-size: 16px;
     }
 
     /* --- Tree nodes: bigger touch targets --- */
@@ -930,9 +940,15 @@
 
     .tv-entry-toggle,
     .tv-entry-remove,
-    .tv-entry-tracker {
+    .tv-entry-tracker,
+    .tv-entry-move {
         opacity: 1;
         padding: 4px;
+    }
+
+    /* Drop targets, not just labels — rows need a real touch target. */
+    .tv-move-picker-row {
+        min-height: 40px;
     }
 
     .tv-entry-drag {
@@ -951,7 +967,7 @@
 
     .tv-expand-content-edit {
         min-height: 100px;
-        font-size: 13px;
+        font-size: 16px;
     }
 
     /* --- Node summary box --- */
@@ -2122,6 +2138,46 @@
 
 .tv-entry-row:hover .tv-entry-remove {
     opacity: 1;
+}
+
+.tv-entry-move {
+    opacity: 0;
+    transition: opacity 0.15s;
+    flex-shrink: 0;
+}
+
+.tv-entry-row:hover .tv-entry-move {
+    opacity: 1;
+}
+
+/* ===== Move-to picker ===== */
+.tv-move-picker {
+    text-align: left;
+    max-height: 60vh;
+    overflow-y: auto;
+    scrollbar-width: thin;
+}
+
+.tv-move-picker-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--SmartThemeQuoteColor, #888);
+    padding: 0 8px 8px;
+    border-bottom: 1px solid var(--SmartThemeBorderColor, #444);
+    margin-bottom: 6px;
+}
+
+.tv-move-picker-row.is-current {
+    opacity: 0.6;
+    cursor: default;
+}
+
+.tv-move-picker-here {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--SmartThemeQuoteColor, #888);
+    margin-left: 6px;
 }
 
 /* Inline expand */

--- a/style.css
+++ b/style.css
@@ -827,32 +827,34 @@
         right: 16px;
     }
 
-    /* --- Tree editor popup: stack sidebar above main panel ---
-       The sidebar and main panel must keep their own scroll regions here.
-       .tv-popup-editor is height: 100%, so the editor can never grow past the
-       popup and .popup-content has nothing to scroll -- take the inner
-       scrollers away and the overflow becomes unreachable instead. */
+    /* --- Tree editor popup: drop the sidebar, navigate in the main panel ---
+       Stacking the sidebar above the main panel meant tapping a node at the top,
+       scrolling past the whole tree to reach its entries, then scrolling back up
+       for the next one. The main panel is already a drill-down navigator -- the
+       breadcrumb goes up, the child cards go down -- so the sidebar is a second
+       navigator for the same tree, and hiding it gives the panel the full height
+       with one scroll region. */
     .tv-popup-body {
         flex-direction: column;
     }
 
     .tv-tree-sidebar {
-        width: 100%;
-        max-height: 40vh;
-        border-right: none;
-        border-bottom: 1px solid var(--SmartThemeBorderColor, #444);
-    }
-
-    .tv-tree-sidebar-header {
-        padding: 6px 10px;
-    }
-
-    .tv-tree-sidebar-scroll {
-        padding: 4px;
+        display: none;
     }
 
     .tv-main-panel {
         min-height: 200px;
+    }
+
+    /* The breadcrumb is the back button here, so it needs a real touch target. */
+    .tv-main-breadcrumb {
+        font-size: 13px;
+        gap: 6px;
+        margin-bottom: 6px;
+    }
+
+    .tv-bc-crumb {
+        padding: 4px 2px;
     }
 
     .tv-main-header {
@@ -981,11 +983,6 @@
     /* --- Child node cards: stack vertically --- */
     .tv-child-cards {
         gap: 6px;
-    }
-
-    /* --- Breadcrumbs --- */
-    .tv-main-breadcrumb {
-        font-size: 10px;
     }
 
     /* --- Kanban mini overview --- */
@@ -2642,6 +2639,17 @@
 .tv-child-card:hover {
     border-color: rgba(108, 92, 231, 0.3);
     background: rgba(108, 92, 231, 0.07);
+}
+
+/* Unassigned is not a real category -- keep it neutral so it reads as a
+   holding pen rather than a sibling of the tree's own nodes. */
+.tv-child-card-unassigned {
+    background: var(--black30a, rgba(0, 0, 0, 0.15));
+    border-color: var(--SmartThemeBorderColor, #444);
+}
+
+.tv-child-card-unassigned .tv-child-card-name {
+    color: var(--SmartThemeQuoteColor, #888);
 }
 
 .tv-child-card-info {

--- a/tests/tree-move.test.js
+++ b/tests/tree-move.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { createEmptyTree, createTreeNode, flattenNodes } from '../tree-store.js';
+
+// ── flattenNodes ─────────────────────────────────────────────────
+// Backs the "Move to…" picker: the tree is a nested structure but the
+// picker needs a flat, indented list of every possible destination.
+
+describe('flattenNodes', () => {
+    it('returns just the root for a tree with no categories', () => {
+        const tree = createEmptyTree();
+        expect(flattenNodes(tree.root)).toEqual([{ node: tree.root, depth: 0 }]);
+    });
+
+    it('walks depth-first and records nesting depth', () => {
+        const tree = createEmptyTree();
+        const locations = createTreeNode('Locations');
+        const ruins = createTreeNode('Ruins');
+        const cities = createTreeNode('Cities');
+        const characters = createTreeNode('Characters');
+        locations.children = [ruins, cities];
+        tree.root.children = [locations, characters];
+
+        expect(flattenNodes(tree.root).map(e => [e.node.label, e.depth])).toEqual([
+            [tree.root.label, 0],
+            ['Locations', 1],
+            ['Ruins', 2],
+            ['Cities', 2],
+            ['Characters', 1],
+        ]);
+    });
+
+    it('ignores the collapsed flag — every node is a valid destination', () => {
+        const tree = createEmptyTree();
+        const hidden = createTreeNode('Hidden');
+        hidden.children = [createTreeNode('Deep')];
+        tree.root.children = [hidden];
+        tree.root.collapsed = true;
+        hidden.collapsed = true;
+
+        expect(flattenNodes(tree.root)).toHaveLength(3);
+    });
+
+    it('returns an empty list for a missing node', () => {
+        expect(flattenNodes(null)).toEqual([]);
+    });
+});

--- a/tree-store.js
+++ b/tree-store.js
@@ -230,6 +230,23 @@ export function getAllEntryUids(node) {
 }
 
 /**
+ * Flatten the tree into a depth-first list of every node with its nesting
+ * depth. Used by the "Move to…" picker, which needs a flat indented list of
+ * destinations; collapsed nodes are included, since collapse is a view state.
+ * @param {TreeNode} node
+ * @param {number} depth
+ * @returns {{ node: TreeNode, depth: number }[]}
+ */
+export function flattenNodes(node, depth = 0) {
+    if (!node) return [];
+    const flat = [{ node, depth }];
+    for (const child of (node.children || [])) {
+        flat.push(...flattenNodes(child, depth + 1));
+    }
+    return flat;
+}
+
+/**
  * Build a text representation of the tree for the LLM tool description.
  * This is what the model sees when deciding which branch to search.
  * @param {TreeNode} node

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -20,6 +20,7 @@ import {
     removeEntryFromTree,
     getAllEntryUids,
     flattenNodes,
+    findNodeById,
     getSettings,
     getBookDescription,
     setBookDescription,
@@ -2362,12 +2363,19 @@ async function onOpenTreeEditor() {
 
     // Wire toolbar buttons BEFORE showing popup (callGenericPopup awaits until close)
     $popup.find('#tv_popup_add_cat').on('click', () => {
-        tree.root.children = tree.root.children || [];
-        tree.root.children.push(createTreeNode('New Category'));
-        tree.root.collapsed = false;
+        // Add under the node being viewed, not always the root. Resolve it by id
+        // rather than trusting the reference: an external refresh replaces
+        // tree.root wholesale, which would leave selectedNode pointing at a
+        // detached node whose new child is never saved. Unassigned is a pseudo-
+        // node that is not in the tree at all, so it falls back to root too.
+        const target = (selectedNode && selectedNode.id !== '__unassigned__'
+            ? findNodeById(tree.root, selectedNode.id)
+            : null) || tree.root;
+        target.children = target.children || [];
+        target.children.push(createTreeNode(target === tree.root ? 'New Category' : 'New Sub-category'));
+        target.collapsed = false;
         saveTree(bookName, tree);
-        renderTreeNodes();
-        renderMainPanel();
+        selectNode(target);
         registerTools();
     });
 

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -19,6 +19,7 @@ import {
     removeNode,
     removeEntryFromTree,
     getAllEntryUids,
+    flattenNodes,
     getSettings,
     getBookDescription,
     setBookDescription,
@@ -43,7 +44,7 @@ import { clearRetrievalPrompt } from './sidecar-retrieval.js';
 import { applyRecurseLimit } from './index.js';
 import { refreshHiddenToolCallMessages } from './activity-feed.js';
 import { separateConditions, isEvaluableCondition, formatCondition, EVALUABLE_TYPES, CONDITION_LABELS, getKeywordProbability, setKeywordProbability } from './conditions.js';
-import { callGenericPopup, POPUP_TYPE } from '../../../popup.js';
+import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from '../../../popup.js';
 
 
 let currentLorebook = null;
@@ -1739,6 +1740,42 @@ async function onOpenTreeEditor() {
         saveTree(bookName, tree);
     }
 
+    /**
+     * Pick a destination node for an entry from a flat, indented list.
+     * Touch devices get no HTML5 drag events at all, so this is the only way
+     * to assign an entry on a phone — and it beats dragging across the panel
+     * on a deep tree with a mouse too.
+     */
+    async function openMovePicker(uid, entryLabel, currentNode) {
+        const $list = $('<div class="tv-move-picker"></div>');
+        $list.append($('<div class="tv-move-picker-title"></div>').text(`Move "${entryLabel}" to…`));
+
+        const picker = new Popup($list, POPUP_TYPE.TEXT, '', { okButton: false, cancelButton: 'Cancel' });
+
+        for (const { node, depth } of flattenNodes(tree.root)) {
+            const isCurrent = node.id === currentNode?.id;
+            const $row = $(`<div class="tv-tree-row tv-move-picker-row${isCurrent ? ' is-current' : ''}"></div>`);
+            $row.css('padding-left', `${8 + depth * 14}px`);
+            $row.append($('<span class="tv-tree-dot"></span>'));
+            $row.append($('<span class="tv-tree-label"></span>').text(node === tree.root ? 'Root' : (node.label || 'Unnamed')));
+            $row.append($(`<span class="tv-tree-count">${countActiveEntries(node)}</span>`));
+            if (isCurrent) {
+                $row.append($('<span class="tv-move-picker-here">here</span>'));
+            } else {
+                $row.on('click', async () => {
+                    assignEntryToNode(uid, node);
+                    await picker.complete(POPUP_RESULT.CANCELLED);
+                    selectNode(node);
+                    await renderUnassignedEntries(bookName, tree, bookData);
+                    registerTools();
+                });
+            }
+            $list.append($row);
+        }
+
+        await picker.show();
+    }
+
     function renderTreeNodes() {
         $treeScroll.empty();
         $treeScroll.append(buildTreeNode(tree.root, 0, { isRoot: true }));
@@ -2049,6 +2086,14 @@ async function onOpenTreeEditor() {
             if (isDisabled) $row.addClass('is-disabled');
         }
 
+        // Move to another category. Drag-and-drop below only fires on desktop.
+        const $move = $('<button class="tv-btn-icon tv-entry-move" title="Move to category"><i class="fa-solid fa-arrow-turn-down"></i></button>');
+        $move.on('click', (e) => {
+            e.stopPropagation();
+            openMovePicker(uid, label, isUnassigned ? null : node);
+        });
+        $row.append($move);
+
         if (!isUnassigned) {
             const $remove = $('<button class="tv-btn-icon tv-btn-danger-icon tv-entry-remove" title="Remove from node"><i class="fa-solid fa-xmark"></i></button>');
             $remove.on('click', async (e) => {
@@ -2353,7 +2398,10 @@ async function onOpenTreeEditor() {
     try {
         await callGenericPopup($popup, POPUP_TYPE.DISPLAY, '', {
             large: true,
-            wide: true,
+            // `wide` sets min-width: var(--sheldWidth), and min-width beats the
+            // popup's own max-width — on a phone that pushes the right-hand
+            // toolbar off-screen with horizontal scrolling disabled.
+            wide: window.innerWidth > 768,
             allowVerticalScrolling: true,
             allowHorizontalScrolling: false,
         });

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -2028,6 +2028,29 @@ async function onOpenTreeEditor() {
             $body.append($cards);
         }
 
+        // Unassigned is a sidebar-only pseudo-node, and the sidebar is hidden on
+        // mobile -- surface it as a card on the root so it stays reachable.
+        if (isRoot) {
+            const unassigned = getUnassignedEntries(bookData, tree);
+            if (unassigned.length > 0) {
+                const $card = $('<div class="tv-child-card tv-child-card-unassigned"></div>');
+                $card.append($('<span class="tv-tree-dot" style="opacity:0.4"></span>'));
+                const $info = $('<div class="tv-child-card-info"></div>');
+                $info.append($('<div class="tv-child-card-name"></div>').text('Unassigned'));
+                $info.append($('<div class="tv-child-card-summary"></div>').text('Entries that are not in any category yet.'));
+                $card.append($info);
+                $card.append($(`<span class="tv-child-card-count">${unassigned.length}</span>`));
+                $card.append($('<span class="tv-child-card-arrow">▸</span>'));
+                $card.on('click', () => selectNode({
+                    id: '__unassigned__',
+                    label: 'Unassigned',
+                    entryUids: unassigned.map(e => e.uid),
+                    children: [],
+                }));
+                $body.append($('<div class="tv-child-cards"></div>').append($card));
+            }
+        }
+
         $mainPanel.append($body);
     }
 

--- a/ui-controller.js
+++ b/ui-controller.js
@@ -2063,6 +2063,17 @@ async function onOpenTreeEditor() {
         $row.append($('<span class="tv-entry-name"></span>').text(label));
         $row.append($(`<span class="tv-entry-uid">#${uid}</span>`));
 
+        // Move to another category. Drag-and-drop below only fires on desktop, so
+        // on a phone this is the only way to assign an entry -- it leads the
+        // action group, with the tracker and visibility toggles between it and
+        // the remove button so a thumb cannot stray from one to the other.
+        const $move = $('<button class="tv-btn-icon tv-entry-move" title="Move to category"><i class="fa-solid fa-arrow-turn-down"></i></button>');
+        $move.on('click', (e) => {
+            e.stopPropagation();
+            openMovePicker(uid, label, isUnassigned ? null : node);
+        });
+        $row.append($move);
+
         // Tracker toggle
         if (entry) {
             const tracked = isTrackerUid(bookName, uid);
@@ -2109,14 +2120,6 @@ async function onOpenTreeEditor() {
             $row.append($toggle);
             if (isDisabled) $row.addClass('is-disabled');
         }
-
-        // Move to another category. Drag-and-drop below only fires on desktop.
-        const $move = $('<button class="tv-btn-icon tv-entry-move" title="Move to category"><i class="fa-solid fa-arrow-turn-down"></i></button>');
-        $move.on('click', (e) => {
-            e.stopPropagation();
-            openMovePicker(uid, label, isUnassigned ? null : node);
-        });
-        $row.append($move);
 
         if (!isUnassigned) {
             const $remove = $('<button class="tv-btn-icon tv-btn-danger-icon tv-entry-remove" title="Remove from node"><i class="fa-solid fa-xmark"></i></button>');


### PR DESCRIPTION
Assigning an entry to a category was drag-and-drop only, and HTML5 drag events
never fire from touch — so on a phone there was no way to do the tree editor's
main job.

Three things were in the way, and only the first was a missing feature.

**Assignment needed a non-drag path.** Every entry row now has a **Move to…**
button that opens a flat, indented list of every category; tap one and the entry
moves. It shows on desktop too, where it beats dragging across the panel on a
deep tree. Drag-and-drop is untouched for anyone who prefers it.

**The layout fought the screen.** The sidebar and the main panel were stacked,
so every move meant tapping a node at the top, scrolling past the whole tree to
reach its entries, then scrolling back up. The main panel was already a
drill-down navigator — the breadcrumb walks up, the child cards walk down — so
the sidebar is now hidden below 768px and the panel gets the full height with a
single scroll region. Unassigned entries, previously reachable only from the
sidebar, appear as a card on the root.

**The mobile stylesheet had never actually applied.** A media query adds no
specificity, so its rules only win by coming later in the file — and this block
sat *above* almost everything it targeted. 33 declarations were silently losing
to the very rules they existed to override: the sidebar never hid, inputs stayed
at 13px (so iOS zoomed on every tap and never zoomed back), and none of the
enlarged touch targets were real. Moving the block to the end of `style.css`
fixed all of them at once, which is why it now carries a comment saying it has
to stay there.

## Reviewing the diff

`style.css` shows ~608 changed lines, but one commit — *Move the mobile block to
the end of the stylesheet* — is 477+/473− and is essentially a pure relocation.
The CSS actually authored across the other five commits is roughly 107 lines.
Reviewing that commit with `--color-moved`, or going commit by commit, makes the
real change legible.

## Tests

4 new tests in `tests/tree-move.test.js` covering the move-to-category path.

`vitest run` on this branch: **475 passing**, against **471** on `main` at
`a01d7ee`. Both runs show the same 91 pre-existing failures in `tree-builder`,
`entry-manager` and `activity-feed` — they reproduce on a clean `main` checkout
and are untouched by this branch.
